### PR TITLE
Add CSV and DCAT parsers with data models

### DIFF
--- a/src/ogd_to_lod/parsers/__init__.py
+++ b/src/ogd_to_lod/parsers/__init__.py
@@ -1,1 +1,30 @@
 """Parsers for CSV and DCAT metadata."""
+
+from .csv_parser import CSVParseError, parse_csv
+from .dcat_parser import DCATParseError, parse_dcat
+from .models import (
+    ColumnInfo,
+    ColumnType,
+    CSVData,
+    DCATMetadata,
+    ParsedInput,
+    SpatialCoverage,
+    TemporalCoverage,
+)
+
+__all__ = [
+    # CSV parser
+    "parse_csv",
+    "CSVParseError",
+    # DCAT parser
+    "parse_dcat",
+    "DCATParseError",
+    # Models
+    "ColumnInfo",
+    "ColumnType",
+    "CSVData",
+    "DCATMetadata",
+    "ParsedInput",
+    "SpatialCoverage",
+    "TemporalCoverage",
+]

--- a/src/ogd_to_lod/parsers/csv_parser.py
+++ b/src/ogd_to_lod/parsers/csv_parser.py
@@ -1,0 +1,327 @@
+"""CSV parser for extracting schema and sample data."""
+
+import csv
+import io
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from .models import ColumnInfo, ColumnType, CSVData
+
+
+class CSVParseError(Exception):
+    """Exception raised when CSV parsing fails."""
+
+    pass
+
+
+def _is_url(source: str) -> bool:
+    """Check if the source is a URL."""
+    try:
+        result = urlparse(source)
+        return result.scheme in ("http", "https")
+    except Exception:
+        return False
+
+
+def _read_file_content(source: str, encoding: str | None = None) -> tuple[str, str]:
+    """Read content from file path or URL.
+
+    Args:
+        source: File path or URL.
+        encoding: Optional encoding to use. If None, will try to detect.
+
+    Returns:
+        Tuple of (content, detected_encoding).
+
+    Raises:
+        CSVParseError: If the file cannot be read.
+    """
+    encodings_to_try = [encoding] if encoding else ["utf-8", "iso-8859-1", "cp1252"]
+
+    if _is_url(source):
+        try:
+            with urlopen(source, timeout=30) as response:
+                raw_content = response.read()
+        except Exception as e:
+            raise CSVParseError(f"Failed to fetch URL '{source}': {e}") from e
+    else:
+        path = Path(source)
+        if not path.exists():
+            raise CSVParseError(f"File not found: {source}")
+        try:
+            raw_content = path.read_bytes()
+        except Exception as e:
+            raise CSVParseError(f"Failed to read file '{source}': {e}") from e
+
+    # Try different encodings
+    for enc in encodings_to_try:
+        if enc is None:
+            continue
+        try:
+            content = raw_content.decode(enc)
+            return content, enc
+        except (UnicodeDecodeError, LookupError):
+            continue
+
+    raise CSVParseError(
+        f"Failed to decode content from '{source}'. "
+        f"Tried encodings: {', '.join(e for e in encodings_to_try if e)}"
+    )
+
+
+def _detect_delimiter(sample: str) -> str:
+    """Detect the CSV delimiter from a sample of the content."""
+    sniffer = csv.Sniffer()
+    try:
+        dialect = sniffer.sniff(sample, delimiters=",;\t|")
+        return dialect.delimiter
+    except csv.Error:
+        # Default to comma if detection fails
+        return ","
+
+
+def _is_integer(value: str) -> bool:
+    """Check if a string value represents an integer."""
+    if not value:
+        return False
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_float(value: str) -> bool:
+    """Check if a string value represents a float."""
+    if not value:
+        return False
+    try:
+        float(value)
+        # Make sure it's actually a float, not an integer
+        return "." in value or "e" in value.lower()
+    except ValueError:
+        return False
+
+
+def _is_boolean(value: str) -> bool:
+    """Check if a string value represents a boolean."""
+    return value.lower() in ("true", "false", "yes", "no", "1", "0")
+
+
+# Common date formats to try
+DATE_FORMATS = [
+    "%Y-%m-%d",
+    "%d.%m.%Y",
+    "%d/%m/%Y",
+    "%m/%d/%Y",
+    "%Y/%m/%d",
+    "%d-%m-%Y",
+    "%Y",
+]
+
+DATETIME_FORMATS = [
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%d %H:%M:%S",
+    "%d.%m.%Y %H:%M:%S",
+    "%d/%m/%Y %H:%M:%S",
+]
+
+
+def _is_date(value: str) -> bool:
+    """Check if a string value represents a date."""
+    if not value or len(value) < 4:
+        return False
+
+    for fmt in DATE_FORMATS:
+        try:
+            datetime.strptime(value, fmt)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _is_datetime(value: str) -> bool:
+    """Check if a string value represents a datetime."""
+    if not value:
+        return False
+
+    for fmt in DATETIME_FORMATS:
+        try:
+            datetime.strptime(value, fmt)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _detect_column_type(values: list[str]) -> ColumnType:
+    """Detect the type of a column from sample values.
+
+    Args:
+        values: List of string values from the column.
+
+    Returns:
+        Detected column type.
+    """
+    # Filter out empty values
+    non_empty = [v.strip() for v in values if v and v.strip()]
+
+    if not non_empty:
+        return ColumnType.STRING
+
+    # Count type matches
+    int_count = sum(1 for v in non_empty if _is_integer(v))
+    float_count = sum(1 for v in non_empty if _is_float(v))
+    bool_count = sum(1 for v in non_empty if _is_boolean(v))
+    datetime_count = sum(1 for v in non_empty if _is_datetime(v))
+    date_count = sum(1 for v in non_empty if _is_date(v))
+
+    total = len(non_empty)
+    threshold = 0.8  # 80% of values must match the type
+
+    # Check types in order of specificity
+    if datetime_count / total >= threshold:
+        return ColumnType.DATETIME
+    if date_count / total >= threshold:
+        return ColumnType.DATE
+    if float_count / total >= threshold:
+        return ColumnType.FLOAT
+    if int_count / total >= threshold:
+        return ColumnType.INTEGER
+    if bool_count / total >= threshold:
+        return ColumnType.BOOLEAN
+
+    return ColumnType.STRING
+
+
+def _convert_value(value: str, col_type: ColumnType) -> Any:
+    """Convert a string value to its detected type.
+
+    Args:
+        value: String value to convert.
+        col_type: Target column type.
+
+    Returns:
+        Converted value.
+    """
+    if not value or not value.strip():
+        return None
+
+    value = value.strip()
+
+    try:
+        if col_type == ColumnType.INTEGER:
+            return int(value)
+        elif col_type == ColumnType.FLOAT:
+            return float(value)
+        elif col_type == ColumnType.BOOLEAN:
+            return value.lower() in ("true", "yes", "1")
+        else:
+            # For date, datetime, and string types, keep as string
+            return value
+    except (ValueError, TypeError):
+        return value
+
+
+def parse_csv(
+    source: str,
+    encoding: str | None = None,
+    delimiter: str | None = None,
+    sample_rows: int = 5,
+) -> CSVData:
+    """Parse a CSV file and extract schema information.
+
+    Args:
+        source: File path or URL to the CSV file.
+        encoding: Optional encoding to use. If None, will try to detect.
+        delimiter: Optional delimiter to use. If None, will try to detect.
+        sample_rows: Number of sample rows to extract (default: 5).
+
+    Returns:
+        CSVData object containing parsed information.
+
+    Raises:
+        CSVParseError: If the CSV cannot be parsed.
+    """
+    # Read content
+    content, detected_encoding = _read_file_content(source, encoding)
+
+    # Detect delimiter if not provided
+    if delimiter is None:
+        delimiter = _detect_delimiter(content[:2000])
+
+    # Parse CSV
+    try:
+        reader = csv.DictReader(io.StringIO(content), delimiter=delimiter)
+
+        if reader.fieldnames is None:
+            raise CSVParseError(f"CSV file '{source}' has no header row")
+
+        # Validate fieldnames
+        fieldnames = list(reader.fieldnames)
+        if not fieldnames:
+            raise CSVParseError(f"CSV file '{source}' has no columns")
+
+        # Read all rows to get total count and detect types
+        all_rows: list[dict[str, str]] = []
+        column_values: dict[str, list[str]] = {name: [] for name in fieldnames}
+
+        for row in reader:
+            all_rows.append(row)
+            for name in fieldnames:
+                column_values[name].append(row.get(name, ""))
+
+        total_rows = len(all_rows)
+
+        if total_rows == 0:
+            raise CSVParseError(f"CSV file '{source}' has no data rows")
+
+        # Detect column types using sample of values
+        columns: list[ColumnInfo] = []
+        for name in fieldnames:
+            # Use up to 100 values for type detection
+            sample_for_detection = column_values[name][:100]
+            detected_type = _detect_column_type(sample_for_detection)
+
+            # Get sample values for display
+            sample_vals = [
+                _convert_value(v, detected_type)
+                for v in column_values[name][:sample_rows]
+            ]
+
+            columns.append(
+                ColumnInfo(
+                    name=name,
+                    detected_type=detected_type,
+                    sample_values=sample_vals,
+                )
+            )
+
+        # Build column type mapping for row conversion
+        col_types = {col.name: col.detected_type for col in columns}
+
+        # Convert sample rows
+        sample_data: list[dict[str, Any]] = []
+        for row in all_rows[:sample_rows]:
+            converted_row = {
+                name: _convert_value(row.get(name, ""), col_types[name])
+                for name in fieldnames
+            }
+            sample_data.append(converted_row)
+
+        return CSVData(
+            source=source,
+            columns=columns,
+            sample_rows=sample_data,
+            total_rows=total_rows,
+            encoding=detected_encoding,
+            delimiter=delimiter,
+        )
+
+    except csv.Error as e:
+        raise CSVParseError(f"Failed to parse CSV '{source}': {e}") from e

--- a/src/ogd_to_lod/parsers/dcat_parser.py
+++ b/src/ogd_to_lod/parsers/dcat_parser.py
@@ -1,0 +1,458 @@
+"""DCAT metadata parser supporting JSON-LD and Turtle formats."""
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+from .models import DCATMetadata, SpatialCoverage, TemporalCoverage
+
+
+class DCATParseError(Exception):
+    """Exception raised when DCAT parsing fails."""
+
+    pass
+
+
+# Common DCAT namespace prefixes
+DCAT_NS = "http://www.w3.org/ns/dcat#"
+DCT_NS = "http://purl.org/dc/terms/"
+FOAF_NS = "http://xmlns.com/foaf/0.1/"
+SCHEMA_NS = "http://schema.org/"
+VCARD_NS = "http://www.w3.org/2006/vcard/ns#"
+
+
+def _is_url(source: str) -> bool:
+    """Check if the source is a URL."""
+    try:
+        result = urlparse(source)
+        return result.scheme in ("http", "https")
+    except Exception:
+        return False
+
+
+def _read_content(source: str) -> tuple[str, str]:
+    """Read content from file path or URL.
+
+    Args:
+        source: File path or URL.
+
+    Returns:
+        Tuple of (content, format_hint based on extension/content-type).
+
+    Raises:
+        DCATParseError: If the content cannot be read.
+    """
+    format_hint = "unknown"
+
+    if _is_url(source):
+        try:
+            with urlopen(source, timeout=30) as response:
+                content = response.read().decode("utf-8")
+                content_type = response.headers.get("Content-Type", "")
+
+                if "json" in content_type:
+                    format_hint = "json-ld"
+                elif "turtle" in content_type or "ttl" in content_type:
+                    format_hint = "turtle"
+                elif "rdf" in content_type or "xml" in content_type:
+                    format_hint = "rdf-xml"
+        except Exception as e:
+            raise DCATParseError(f"Failed to fetch URL '{source}': {e}") from e
+    else:
+        path = Path(source)
+        if not path.exists():
+            raise DCATParseError(f"File not found: {source}")
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            try:
+                content = path.read_text(encoding="iso-8859-1")
+            except Exception as e:
+                raise DCATParseError(f"Failed to read file '{source}': {e}") from e
+        except Exception as e:
+            raise DCATParseError(f"Failed to read file '{source}': {e}") from e
+
+        # Detect format from extension
+        suffix = path.suffix.lower()
+        if suffix in (".json", ".jsonld"):
+            format_hint = "json-ld"
+        elif suffix in (".ttl", ".turtle"):
+            format_hint = "turtle"
+        elif suffix in (".rdf", ".xml"):
+            format_hint = "rdf-xml"
+
+    return content, format_hint
+
+
+def _get_value(obj: Any, *keys: str) -> str | None:
+    """Extract a value from a nested dict structure, trying multiple keys.
+
+    Args:
+        obj: The object to extract from.
+        *keys: Keys to try in order.
+
+    Returns:
+        The found value as string, or None.
+    """
+    if obj is None:
+        return None
+
+    for key in keys:
+        if isinstance(obj, dict):
+            val = obj.get(key)
+            if val is not None:
+                if isinstance(val, str):
+                    return val
+                elif isinstance(val, dict):
+                    # Handle @value pattern in JSON-LD
+                    if "@value" in val:
+                        return str(val["@value"])
+                    # Handle @id pattern
+                    if "@id" in val:
+                        return str(val["@id"])
+                    # Handle name/value nested objects
+                    if "name" in val:
+                        return _get_value(val, "name")
+                elif isinstance(val, list) and val:
+                    # Take first value if list
+                    return _get_value(val[0], "@value", "@id", "name") or str(val[0])
+                else:
+                    return str(val)
+    return None
+
+
+def _get_list(obj: Any, *keys: str) -> list[str]:
+    """Extract a list of values from a nested dict structure.
+
+    Args:
+        obj: The object to extract from.
+        *keys: Keys to try in order.
+
+    Returns:
+        List of string values.
+    """
+    if obj is None:
+        return []
+
+    for key in keys:
+        if isinstance(obj, dict):
+            val = obj.get(key)
+            if val is not None:
+                if isinstance(val, list):
+                    result = []
+                    for item in val:
+                        if isinstance(item, str):
+                            result.append(item)
+                        elif isinstance(item, dict):
+                            v = _get_value(item, "@value", "@id", "name", "prefLabel")
+                            if v:
+                                result.append(v)
+                    return result
+                elif isinstance(val, str):
+                    return [val]
+    return []
+
+
+def _parse_temporal_coverage(obj: Any) -> TemporalCoverage | None:
+    """Parse temporal coverage from DCAT metadata.
+
+    Args:
+        obj: The temporal coverage object.
+
+    Returns:
+        TemporalCoverage or None.
+    """
+    if obj is None:
+        return None
+
+    if isinstance(obj, str):
+        # Simple string format, try to parse as period
+        if "/" in obj:
+            parts = obj.split("/")
+            end_date = parts[1] if len(parts) > 1 else None
+            return TemporalCoverage(start_date=parts[0], end_date=end_date)
+        return TemporalCoverage(start_date=obj)
+
+    if isinstance(obj, dict):
+        start = _get_value(obj, "startDate", "start", "dct:startDate", "schema:startDate")
+        end = _get_value(obj, "endDate", "end", "dct:endDate", "schema:endDate")
+        return TemporalCoverage(start_date=start, end_date=end)
+
+    if isinstance(obj, list) and obj:
+        return _parse_temporal_coverage(obj[0])
+
+    return None
+
+
+def _parse_spatial_coverage(obj: Any) -> SpatialCoverage | None:
+    """Parse spatial coverage from DCAT metadata.
+
+    Args:
+        obj: The spatial coverage object.
+
+    Returns:
+        SpatialCoverage or None.
+    """
+    if obj is None:
+        return None
+
+    if isinstance(obj, str):
+        return SpatialCoverage(location=obj)
+
+    if isinstance(obj, dict):
+        location = _get_value(
+            obj, "name", "prefLabel", "@id", "geo:name", "schema:name", "rdfs:label"
+        )
+        geometry = _get_value(obj, "geometry", "geo:geometry", "locn:geometry")
+        bbox = _get_value(obj, "bbox", "dcat:bbox")
+        return SpatialCoverage(location=location, geometry=geometry, bbox=bbox)
+
+    if isinstance(obj, list) and obj:
+        return _parse_spatial_coverage(obj[0])
+
+    return None
+
+
+def _parse_json_ld(content: str, source: str) -> DCATMetadata:
+    """Parse DCAT metadata from JSON-LD content.
+
+    Args:
+        content: JSON-LD content string.
+        source: Original source path/URL.
+
+    Returns:
+        Parsed DCATMetadata.
+
+    Raises:
+        DCATParseError: If parsing fails.
+    """
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        raise DCATParseError(f"Invalid JSON-LD in '{source}': {e}") from e
+
+    # Handle @graph structure
+    if isinstance(data, dict) and "@graph" in data:
+        graph = data["@graph"]
+        # Find the Dataset entry
+        dataset = None
+        for item in graph:
+            item_type = item.get("@type", "")
+            if isinstance(item_type, list):
+                if "dcat:Dataset" in item_type or "Dataset" in item_type:
+                    dataset = item
+                    break
+            elif "Dataset" in item_type:
+                dataset = item
+                break
+        if dataset is None and graph:
+            dataset = graph[0]
+        data = dataset or data
+
+    # Handle array of datasets
+    if isinstance(data, list):
+        if not data:
+            raise DCATParseError(f"Empty JSON-LD array in '{source}'")
+        data = data[0]
+
+    if not isinstance(data, dict):
+        raise DCATParseError(f"Invalid JSON-LD structure in '{source}'")
+
+    # Extract fields with multiple key variants
+    title = _get_value(data, "title", "dct:title", "dcterms:title", "schema:name", "name")
+    description = _get_value(
+        data, "description", "dct:description", "dcterms:description", "schema:description"
+    )
+
+    # Publisher can be nested
+    publisher_obj = (
+        data.get("publisher") or data.get("dct:publisher") or data.get("dcterms:publisher")
+    )
+    publisher = None
+    if publisher_obj:
+        if isinstance(publisher_obj, str):
+            publisher = publisher_obj
+        elif isinstance(publisher_obj, dict):
+            publisher = _get_value(publisher_obj, "name", "foaf:name", "schema:name", "@id")
+        elif isinstance(publisher_obj, list) and publisher_obj:
+            publisher = _get_value(publisher_obj[0], "name", "foaf:name", "schema:name", "@id")
+
+    # Keywords
+    keywords = _get_list(data, "keyword", "keywords", "dcat:keyword", "dct:keyword")
+
+    # Temporal coverage
+    temporal_obj = data.get("temporal") or data.get("dct:temporal") or data.get("dcterms:temporal")
+    temporal_coverage = _parse_temporal_coverage(temporal_obj)
+
+    # Spatial coverage
+    spatial_obj = data.get("spatial") or data.get("dct:spatial") or data.get("dcterms:spatial")
+    spatial_coverage = _parse_spatial_coverage(spatial_obj)
+
+    # Other fields
+    identifier = _get_value(data, "identifier", "dct:identifier", "dcterms:identifier", "@id")
+    issued = _get_value(data, "issued", "dct:issued", "dcterms:issued")
+    modified = _get_value(data, "modified", "dct:modified", "dcterms:modified")
+    language = _get_value(data, "language", "dct:language", "dcterms:language")
+    license_val = _get_value(data, "license", "dct:license", "dcterms:license")
+    access_rights = _get_value(data, "accessRights", "dct:accessRights", "dcterms:accessRights")
+
+    # Contact point
+    contact_obj = data.get("contactPoint") or data.get("dcat:contactPoint")
+    contact_point = None
+    if contact_obj:
+        if isinstance(contact_obj, str):
+            contact_point = contact_obj
+        elif isinstance(contact_obj, dict):
+            contact_point = _get_value(
+                contact_obj, "fn", "vcard:fn", "email", "vcard:hasEmail", "name"
+            )
+
+    return DCATMetadata(
+        source=source,
+        title=title,
+        description=description,
+        publisher=publisher,
+        keywords=keywords,
+        temporal_coverage=temporal_coverage,
+        spatial_coverage=spatial_coverage,
+        identifier=identifier,
+        issued=issued,
+        modified=modified,
+        language=language,
+        license=license_val,
+        access_rights=access_rights,
+        contact_point=contact_point,
+    )
+
+
+def _parse_turtle(content: str, source: str) -> DCATMetadata:
+    """Parse DCAT metadata from Turtle content.
+
+    This is a simplified parser that extracts common patterns.
+    For full RDF parsing, consider using rdflib.
+
+    Args:
+        content: Turtle content string.
+        source: Original source path/URL.
+
+    Returns:
+        Parsed DCATMetadata.
+
+    Raises:
+        DCATParseError: If parsing fails.
+    """
+    import re
+
+    # Helper to extract literal values
+    def extract_literal(pattern: str) -> str | None:
+        match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+        if match:
+            val = match.group(1).strip()
+            # Remove language tag
+            if "@" in val:
+                val = val.split("@")[0]
+            # Remove quotes
+            val = val.strip('"').strip("'")
+            return val
+        return None
+
+    def extract_literals(pattern: str) -> list[str]:
+        matches = re.findall(pattern, content, re.MULTILINE)
+        return [m.strip().strip('"').strip("'").split("@")[0] for m in matches]
+
+    # Common property patterns
+    title_pattern = r'(?:dct|dcterms):title\s+["\'](.+?)["\']'
+    desc_pattern = r'(?:dct|dcterms):description\s+["\'](.+?)["\']'
+    publisher_pattern = r'(?:dct|dcterms):publisher\s+(?:<([^>]+)>|["\'](.+?)["\'])'
+    keyword_pattern = r'(?:dcat):keyword\s+["\']([^"\']+)["\']'
+    identifier_pattern = r'(?:dct|dcterms):identifier\s+["\'](.+?)["\']'
+    issued_pattern = r'(?:dct|dcterms):issued\s+["\'](.+?)["\']'
+    modified_pattern = r'(?:dct|dcterms):modified\s+["\'](.+?)["\']'
+
+    title = extract_literal(title_pattern)
+    description = extract_literal(desc_pattern)
+    keywords = extract_literals(keyword_pattern)
+    identifier = extract_literal(identifier_pattern)
+    issued = extract_literal(issued_pattern)
+    modified = extract_literal(modified_pattern)
+
+    # Publisher
+    publisher_match = re.search(publisher_pattern, content)
+    publisher = None
+    if publisher_match:
+        publisher = publisher_match.group(1) or publisher_match.group(2)
+
+    # Temporal coverage
+    temporal_start = extract_literal(r'(?:dcat|dct|dcterms):startDate\s+["\'](.+?)["\']')
+    temporal_end = extract_literal(r'(?:dcat|dct|dcterms):endDate\s+["\'](.+?)["\']')
+    temporal_coverage = None
+    if temporal_start or temporal_end:
+        temporal_coverage = TemporalCoverage(start_date=temporal_start, end_date=temporal_end)
+
+    # Spatial coverage
+    spatial_location = extract_literal(r'(?:dct|dcterms):spatial\s+(?:<([^>]+)>|["\'](.+?)["\'])')
+    spatial_coverage = None
+    if spatial_location:
+        spatial_coverage = SpatialCoverage(location=spatial_location)
+
+    return DCATMetadata(
+        source=source,
+        title=title,
+        description=description,
+        publisher=publisher,
+        keywords=keywords,
+        temporal_coverage=temporal_coverage,
+        spatial_coverage=spatial_coverage,
+        identifier=identifier,
+        issued=issued,
+        modified=modified,
+    )
+
+
+def parse_dcat(source: str, format_hint: str | None = None) -> DCATMetadata:
+    """Parse DCAT metadata from a file or URL.
+
+    Args:
+        source: File path or URL to the DCAT metadata.
+        format_hint: Optional format hint ('json-ld', 'turtle'). If None, will try to detect.
+
+    Returns:
+        DCATMetadata object containing parsed information.
+
+    Raises:
+        DCATParseError: If the DCAT metadata cannot be parsed.
+    """
+    content, detected_format = _read_content(source)
+
+    # Use provided format or detected one
+    fmt = format_hint or detected_format
+
+    # Try to detect format from content if still unknown
+    if fmt == "unknown":
+        content_stripped = content.strip()
+        if content_stripped.startswith("{") or content_stripped.startswith("["):
+            fmt = "json-ld"
+        elif "@prefix" in content or content_stripped.startswith("<"):
+            fmt = "turtle"
+        else:
+            fmt = "json-ld"  # Default to JSON-LD
+
+    if fmt == "json-ld":
+        return _parse_json_ld(content, source)
+    elif fmt in ("turtle", "ttl"):
+        return _parse_turtle(content, source)
+    else:
+        # Try JSON-LD first, then Turtle
+        try:
+            return _parse_json_ld(content, source)
+        except DCATParseError:
+            try:
+                return _parse_turtle(content, source)
+            except Exception as e:
+                raise DCATParseError(
+                    f"Failed to parse DCAT metadata from '{source}'. "
+                    f"Tried JSON-LD and Turtle formats. Error: {e}"
+                ) from e

--- a/src/ogd_to_lod/parsers/models.py
+++ b/src/ogd_to_lod/parsers/models.py
@@ -1,0 +1,133 @@
+"""Data models for parsed CSV and DCAT input."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ColumnType(Enum):
+    """Detected column data types."""
+
+    STRING = "string"
+    INTEGER = "int"
+    FLOAT = "float"
+    DATE = "date"
+    DATETIME = "datetime"
+    BOOLEAN = "boolean"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ColumnInfo:
+    """Information about a CSV column."""
+
+    name: str
+    detected_type: ColumnType
+    sample_values: list[Any] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Ensure sample_values is a list."""
+        if self.sample_values is None:
+            self.sample_values = []
+
+
+@dataclass
+class CSVData:
+    """Parsed CSV data with schema information."""
+
+    source: str  # File path or URL
+    columns: list[ColumnInfo] = field(default_factory=list)
+    sample_rows: list[dict[str, Any]] = field(default_factory=list)
+    total_rows: int = 0
+    encoding: str = "utf-8"
+    delimiter: str = ","
+
+    def column_names(self) -> list[str]:
+        """Return list of column names."""
+        return [col.name for col in self.columns]
+
+    def column_types(self) -> dict[str, ColumnType]:
+        """Return mapping of column names to detected types."""
+        return {col.name: col.detected_type for col in self.columns}
+
+
+@dataclass
+class TemporalCoverage:
+    """Temporal coverage information from DCAT metadata."""
+
+    start_date: str | None = None
+    end_date: str | None = None
+
+
+@dataclass
+class SpatialCoverage:
+    """Spatial coverage information from DCAT metadata."""
+
+    location: str | None = None
+    geometry: str | None = None
+    bbox: str | None = None
+
+
+@dataclass
+class DCATMetadata:
+    """Parsed DCAT metadata."""
+
+    source: str  # File path or URL
+    title: str | None = None
+    description: str | None = None
+    publisher: str | None = None
+    keywords: list[str] = field(default_factory=list)
+    temporal_coverage: TemporalCoverage | None = None
+    spatial_coverage: SpatialCoverage | None = None
+    identifier: str | None = None
+    issued: str | None = None
+    modified: str | None = None
+    language: str | None = None
+    license: str | None = None
+    access_rights: str | None = None
+    contact_point: str | None = None
+
+    def __post_init__(self) -> None:
+        """Ensure keywords is a list."""
+        if self.keywords is None:
+            self.keywords = []
+
+
+@dataclass
+class ParsedInput:
+    """Unified data model combining CSV data and DCAT metadata."""
+
+    csv_data: CSVData
+    dcat_metadata: DCATMetadata | None = None
+
+    def summary(self) -> str:
+        """Return a human-readable summary of the parsed input."""
+        lines = []
+        lines.append(f"CSV Source: {self.csv_data.source}")
+        lines.append(f"Columns: {len(self.csv_data.columns)}")
+        lines.append(f"Total Rows: {self.csv_data.total_rows}")
+        lines.append(f"Sample Rows: {len(self.csv_data.sample_rows)}")
+        lines.append("")
+        lines.append("Column Details:")
+        for col in self.csv_data.columns:
+            lines.append(f"  - {col.name}: {col.detected_type.value}")
+
+        if self.dcat_metadata:
+            lines.append("")
+            lines.append("DCAT Metadata:")
+            if self.dcat_metadata.title:
+                lines.append(f"  Title: {self.dcat_metadata.title}")
+            if self.dcat_metadata.description:
+                lines.append(f"  Description: {self.dcat_metadata.description[:100]}...")
+            if self.dcat_metadata.publisher:
+                lines.append(f"  Publisher: {self.dcat_metadata.publisher}")
+            if self.dcat_metadata.keywords:
+                lines.append(f"  Keywords: {', '.join(self.dcat_metadata.keywords)}")
+            if self.dcat_metadata.temporal_coverage:
+                tc = self.dcat_metadata.temporal_coverage
+                lines.append(f"  Temporal: {tc.start_date} - {tc.end_date}")
+            if self.dcat_metadata.spatial_coverage:
+                sc = self.dcat_metadata.spatial_coverage
+                lines.append(f"  Spatial: {sc.location}")
+
+        return "\n".join(lines)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,616 @@
+"""Tests for CSV and DCAT parsers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ogd_to_lod.parsers import (
+    ColumnType,
+    CSVData,
+    CSVParseError,
+    DCATMetadata,
+    DCATParseError,
+    ParsedInput,
+    parse_csv,
+    parse_dcat,
+)
+
+
+class TestCSVParser:
+    """Tests for CSV parser."""
+
+    def test_parse_simple_csv(self, tmp_path: Path) -> None:
+        """Test parsing a simple CSV file."""
+        csv_content = """name,age,salary
+Alice,30,50000.50
+Bob,25,45000.75
+Charlie,35,60000.00"""
+        csv_file = tmp_path / "simple.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert isinstance(result, CSVData)
+        assert result.source == str(csv_file)
+        assert len(result.columns) == 3
+        assert result.total_rows == 3
+        assert result.encoding == "utf-8"
+        assert result.delimiter == ","
+
+    def test_column_names_extracted(self, tmp_path: Path) -> None:
+        """Test that column names are correctly extracted."""
+        csv_content = """first_name,last_name,email
+John,Doe,john@example.com"""
+        csv_file = tmp_path / "columns.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.column_names() == ["first_name", "last_name", "email"]
+
+    def test_detect_integer_type(self, tmp_path: Path) -> None:
+        """Test detection of integer column type."""
+        csv_content = """id,count
+1,100
+2,200
+3,300"""
+        csv_file = tmp_path / "integers.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[0].detected_type == ColumnType.INTEGER
+        assert result.columns[1].detected_type == ColumnType.INTEGER
+
+    def test_detect_float_type(self, tmp_path: Path) -> None:
+        """Test detection of float column type."""
+        csv_content = """price,rate
+19.99,0.05
+29.99,0.10
+39.99,0.15"""
+        csv_file = tmp_path / "floats.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[0].detected_type == ColumnType.FLOAT
+        assert result.columns[1].detected_type == ColumnType.FLOAT
+
+    def test_detect_date_type(self, tmp_path: Path) -> None:
+        """Test detection of date column type."""
+        csv_content = """date_iso,date_eu
+2024-01-15,15.01.2024
+2024-02-20,20.02.2024
+2024-03-25,25.03.2024"""
+        csv_file = tmp_path / "dates.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[0].detected_type == ColumnType.DATE
+        assert result.columns[1].detected_type == ColumnType.DATE
+
+    def test_detect_string_type(self, tmp_path: Path) -> None:
+        """Test detection of string column type."""
+        csv_content = """name,city
+Alice,Zurich
+Bob,Geneva
+Charlie,Basel"""
+        csv_file = tmp_path / "strings.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[0].detected_type == ColumnType.STRING
+        assert result.columns[1].detected_type == ColumnType.STRING
+
+    def test_sample_rows_extracted(self, tmp_path: Path) -> None:
+        """Test that sample rows are correctly extracted."""
+        csv_content = """name,value
+row1,1
+row2,2
+row3,3
+row4,4
+row5,5
+row6,6"""
+        csv_file = tmp_path / "rows.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file), sample_rows=3)
+
+        assert len(result.sample_rows) == 3
+        assert result.sample_rows[0]["name"] == "row1"
+        assert result.sample_rows[2]["name"] == "row3"
+        assert result.total_rows == 6
+
+    def test_default_sample_rows_is_five(self, tmp_path: Path) -> None:
+        """Test that default sample rows is 5."""
+        csv_content = """n\n""" + "\n".join(str(i) for i in range(10))
+        csv_file = tmp_path / "ten_rows.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert len(result.sample_rows) == 5
+
+    def test_detect_semicolon_delimiter(self, tmp_path: Path) -> None:
+        """Test detection of semicolon delimiter."""
+        csv_content = """name;age;city
+Alice;30;Zurich
+Bob;25;Geneva"""
+        csv_file = tmp_path / "semicolon.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.delimiter == ";"
+        assert result.column_names() == ["name", "age", "city"]
+
+    def test_explicit_delimiter(self, tmp_path: Path) -> None:
+        """Test using an explicit delimiter."""
+        csv_content = """name|age|city
+Alice|30|Zurich"""
+        csv_file = tmp_path / "pipe.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file), delimiter="|")
+
+        assert result.delimiter == "|"
+        assert result.column_names() == ["name", "age", "city"]
+
+    def test_handle_utf8_encoding(self, tmp_path: Path) -> None:
+        """Test handling UTF-8 encoded content."""
+        csv_content = """name,city
+Müller,Zürich
+Böhm,Genève"""
+        csv_file = tmp_path / "utf8.csv"
+        csv_file.write_text(csv_content, encoding="utf-8")
+
+        result = parse_csv(str(csv_file))
+
+        assert result.encoding == "utf-8"
+        assert result.sample_rows[0]["name"] == "Müller"
+        assert result.sample_rows[0]["city"] == "Zürich"
+
+    def test_handle_iso88591_encoding(self, tmp_path: Path) -> None:
+        """Test handling ISO-8859-1 encoded content."""
+        csv_content = """name,city
+Müller,Zürich
+Böhm,Genève"""
+        csv_file = tmp_path / "iso.csv"
+        csv_file.write_bytes(csv_content.encode("iso-8859-1"))
+
+        result = parse_csv(str(csv_file))
+
+        assert result.encoding == "iso-8859-1"
+        assert result.sample_rows[0]["name"] == "Müller"
+
+    def test_explicit_encoding(self, tmp_path: Path) -> None:
+        """Test using an explicit encoding."""
+        csv_content = """name\ntest"""
+        csv_file = tmp_path / "explicit.csv"
+        csv_file.write_text(csv_content, encoding="utf-8")
+
+        result = parse_csv(str(csv_file), encoding="utf-8")
+
+        assert result.encoding == "utf-8"
+
+    def test_file_not_found_error(self) -> None:
+        """Test error when file does not exist."""
+        with pytest.raises(CSVParseError, match="File not found"):
+            parse_csv("/nonexistent/path/file.csv")
+
+    def test_empty_file_error(self, tmp_path: Path) -> None:
+        """Test error when file has header but no data."""
+        csv_file = tmp_path / "header_only.csv"
+        csv_file.write_text("col1,col2,col3")
+
+        with pytest.raises(CSVParseError, match="no data rows"):
+            parse_csv(str(csv_file))
+
+    def test_no_header_error(self, tmp_path: Path) -> None:
+        """Test error when file is completely empty."""
+        csv_file = tmp_path / "empty.csv"
+        csv_file.write_text("")
+
+        with pytest.raises(CSVParseError, match="no header row"):
+            parse_csv(str(csv_file))
+
+    def test_sample_values_in_columns(self, tmp_path: Path) -> None:
+        """Test that sample values are stored in column info."""
+        csv_content = """value
+10
+20
+30"""
+        csv_file = tmp_path / "values.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[0].sample_values == [10, 20, 30]
+
+    def test_column_types_method(self, tmp_path: Path) -> None:
+        """Test the column_types method."""
+        csv_content = """name,age
+Alice,30"""
+        csv_file = tmp_path / "types.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+        types = result.column_types()
+
+        assert "name" in types
+        assert "age" in types
+        assert types["name"] == ColumnType.STRING
+        assert types["age"] == ColumnType.INTEGER
+
+    def test_mixed_types_default_to_string(self, tmp_path: Path) -> None:
+        """Test that mixed type columns default to string."""
+        csv_content = """value
+10
+hello
+20
+world
+30"""
+        csv_file = tmp_path / "mixed.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        # Less than 80% are integers, so should be string
+        assert result.columns[0].detected_type == ColumnType.STRING
+
+    def test_empty_values_handled(self, tmp_path: Path) -> None:
+        """Test that empty values are handled correctly."""
+        csv_content = """name,value
+Alice,10
+Bob,
+Charlie,30"""
+        csv_file = tmp_path / "empty_values.csv"
+        csv_file.write_text(csv_content)
+
+        result = parse_csv(str(csv_file))
+
+        assert result.columns[1].detected_type == ColumnType.INTEGER
+        assert result.sample_rows[1]["value"] is None
+
+
+class TestDCATParser:
+    """Tests for DCAT parser."""
+
+    def test_parse_json_ld_basic(self, tmp_path: Path) -> None:
+        """Test parsing basic JSON-LD DCAT metadata."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test Dataset",
+            "description": "A test dataset for unit testing",
+            "publisher": {"name": "Test Publisher"},
+            "keyword": ["test", "data", "sample"],
+        })
+        dcat_file = tmp_path / "basic.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert isinstance(result, DCATMetadata)
+        assert result.title == "Test Dataset"
+        assert result.description == "A test dataset for unit testing"
+        assert result.publisher == "Test Publisher"
+        assert result.keywords == ["test", "data", "sample"]
+
+    def test_parse_json_ld_with_dct_prefix(self, tmp_path: Path) -> None:
+        """Test parsing JSON-LD with dct: prefixed properties."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "dct:title": "Prefixed Title",
+            "dct:description": "Prefixed Description",
+            "dct:identifier": "dataset-001",
+        })
+        dcat_file = tmp_path / "prefixed.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.title == "Prefixed Title"
+        assert result.description == "Prefixed Description"
+        assert result.identifier == "dataset-001"
+
+    def test_parse_json_ld_with_graph(self, tmp_path: Path) -> None:
+        """Test parsing JSON-LD with @graph structure."""
+        dcat_content = json.dumps({
+            "@context": {"dcat": "http://www.w3.org/ns/dcat#"},
+            "@graph": [
+                {
+                    "@type": "dcat:Dataset",
+                    "title": "Graph Dataset",
+                    "description": "Dataset in a graph",
+                }
+            ],
+        })
+        dcat_file = tmp_path / "graph.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.title == "Graph Dataset"
+
+    def test_parse_temporal_coverage(self, tmp_path: Path) -> None:
+        """Test parsing temporal coverage."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Temporal Dataset",
+            "temporal": {
+                "startDate": "2020-01-01",
+                "endDate": "2023-12-31",
+            },
+        })
+        dcat_file = tmp_path / "temporal.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.temporal_coverage is not None
+        assert result.temporal_coverage.start_date == "2020-01-01"
+        assert result.temporal_coverage.end_date == "2023-12-31"
+
+    def test_parse_spatial_coverage(self, tmp_path: Path) -> None:
+        """Test parsing spatial coverage."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Spatial Dataset",
+            "spatial": {
+                "name": "Zurich",
+            },
+        })
+        dcat_file = tmp_path / "spatial.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.spatial_coverage is not None
+        assert result.spatial_coverage.location == "Zurich"
+
+    def test_parse_publisher_as_string(self, tmp_path: Path) -> None:
+        """Test parsing publisher as simple string."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "publisher": "Simple Publisher Name",
+        })
+        dcat_file = tmp_path / "publisher_string.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.publisher == "Simple Publisher Name"
+
+    def test_parse_publisher_with_foaf_name(self, tmp_path: Path) -> None:
+        """Test parsing publisher with foaf:name."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "publisher": {"foaf:name": "FOAF Publisher"},
+        })
+        dcat_file = tmp_path / "publisher_foaf.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.publisher == "FOAF Publisher"
+
+    def test_parse_keywords_as_single_string(self, tmp_path: Path) -> None:
+        """Test parsing keywords when provided as single string."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "keyword": "single-keyword",
+        })
+        dcat_file = tmp_path / "keyword_string.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.keywords == ["single-keyword"]
+
+    def test_parse_issued_and_modified(self, tmp_path: Path) -> None:
+        """Test parsing issued and modified dates."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "issued": "2020-01-01",
+            "modified": "2024-06-15",
+        })
+        dcat_file = tmp_path / "dates.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.issued == "2020-01-01"
+        assert result.modified == "2024-06-15"
+
+    def test_parse_license(self, tmp_path: Path) -> None:
+        """Test parsing license information."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "license": "https://creativecommons.org/licenses/by/4.0/",
+        })
+        dcat_file = tmp_path / "license.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.license == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_parse_contact_point(self, tmp_path: Path) -> None:
+        """Test parsing contact point."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Test",
+            "contactPoint": {"fn": "John Doe"},
+        })
+        dcat_file = tmp_path / "contact.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.contact_point == "John Doe"
+
+    def test_parse_turtle_basic(self, tmp_path: Path) -> None:
+        """Test parsing basic Turtle DCAT metadata."""
+        turtle_content = """
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+<https://example.org/dataset/1>
+    a dcat:Dataset ;
+    dct:title "Turtle Dataset" ;
+    dct:description "A dataset in Turtle format" ;
+    dcat:keyword "turtle", "test" .
+"""
+        turtle_file = tmp_path / "basic.ttl"
+        turtle_file.write_text(turtle_content)
+
+        result = parse_dcat(str(turtle_file))
+
+        assert result.title == "Turtle Dataset"
+        assert result.description == "A dataset in Turtle format"
+        assert "turtle" in result.keywords
+
+    def test_file_not_found_error(self) -> None:
+        """Test error when file does not exist."""
+        with pytest.raises(DCATParseError, match="File not found"):
+            parse_dcat("/nonexistent/path/file.json")
+
+    def test_invalid_json_error(self, tmp_path: Path) -> None:
+        """Test error when JSON is invalid."""
+        json_file = tmp_path / "invalid.json"
+        json_file.write_text("{ invalid json }")
+
+        with pytest.raises(DCATParseError, match="Invalid JSON-LD"):
+            parse_dcat(str(json_file))
+
+    def test_format_hint_json_ld(self, tmp_path: Path) -> None:
+        """Test using format_hint for JSON-LD."""
+        dcat_content = json.dumps({"title": "Hint Test"})
+        dcat_file = tmp_path / "hint.txt"  # No extension
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file), format_hint="json-ld")
+
+        assert result.title == "Hint Test"
+
+    def test_parse_array_of_datasets(self, tmp_path: Path) -> None:
+        """Test parsing JSON array containing datasets."""
+        dcat_content = json.dumps([
+            {"@type": "dcat:Dataset", "title": "First Dataset"},
+            {"@type": "dcat:Dataset", "title": "Second Dataset"},
+        ])
+        dcat_file = tmp_path / "array.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        # Should parse first dataset
+        assert result.title == "First Dataset"
+
+    def test_parse_value_with_language_tag(self, tmp_path: Path) -> None:
+        """Test parsing values with @value and @language."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": {"@value": "German Title", "@language": "de"},
+            "description": {"@value": "English Description", "@language": "en"},
+        })
+        dcat_file = tmp_path / "lang.json"
+        dcat_file.write_text(dcat_content)
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.title == "German Title"
+        assert result.description == "English Description"
+
+    def test_handle_utf8_in_dcat(self, tmp_path: Path) -> None:
+        """Test handling UTF-8 in DCAT content."""
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Zürich Bevölkerungsstatistik",
+            "description": "Daten über die Bevölkerung in Zürich",
+            "publisher": {"name": "Stadt Zürich"},
+        })
+        dcat_file = tmp_path / "utf8.json"
+        dcat_file.write_text(dcat_content, encoding="utf-8")
+
+        result = parse_dcat(str(dcat_file))
+
+        assert result.title == "Zürich Bevölkerungsstatistik"
+        assert result.publisher == "Stadt Zürich"
+
+
+class TestParsedInput:
+    """Tests for ParsedInput unified data model."""
+
+    def test_parsed_input_with_both(self, tmp_path: Path) -> None:
+        """Test ParsedInput combining CSV and DCAT data."""
+        # Create CSV
+        csv_content = """name,value\ntest,100"""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text(csv_content)
+
+        # Create DCAT
+        dcat_content = json.dumps({
+            "@type": "dcat:Dataset",
+            "title": "Combined Dataset",
+        })
+        dcat_file = tmp_path / "meta.json"
+        dcat_file.write_text(dcat_content)
+
+        csv_data = parse_csv(str(csv_file))
+        dcat_meta = parse_dcat(str(dcat_file))
+
+        parsed = ParsedInput(csv_data=csv_data, dcat_metadata=dcat_meta)
+
+        assert parsed.csv_data.column_names() == ["name", "value"]
+        assert parsed.dcat_metadata.title == "Combined Dataset"
+
+    def test_parsed_input_without_dcat(self, tmp_path: Path) -> None:
+        """Test ParsedInput with only CSV data."""
+        csv_content = """col1,col2\na,b"""
+        csv_file = tmp_path / "only.csv"
+        csv_file.write_text(csv_content)
+
+        csv_data = parse_csv(str(csv_file))
+        parsed = ParsedInput(csv_data=csv_data)
+
+        assert parsed.csv_data is not None
+        assert parsed.dcat_metadata is None
+
+    def test_summary_method(self, tmp_path: Path) -> None:
+        """Test the summary method."""
+        csv_content = """name,age\nAlice,30\nBob,25"""
+        csv_file = tmp_path / "summary.csv"
+        csv_file.write_text(csv_content)
+
+        dcat_content = json.dumps({
+            "title": "Summary Test",
+            "description": "A test description that is long enough to be truncated",
+            "publisher": {"name": "Test Org"},
+            "keyword": ["test", "summary"],
+        })
+        dcat_file = tmp_path / "summary.json"
+        dcat_file.write_text(dcat_content)
+
+        csv_data = parse_csv(str(csv_file))
+        dcat_meta = parse_dcat(str(dcat_file))
+        parsed = ParsedInput(csv_data=csv_data, dcat_metadata=dcat_meta)
+
+        summary = parsed.summary()
+
+        assert "CSV Source:" in summary
+        assert "Columns: 2" in summary
+        assert "Total Rows: 2" in summary
+        assert "name: string" in summary
+        assert "age: int" in summary
+        assert "Title: Summary Test" in summary
+        assert "Publisher: Test Org" in summary
+        assert "Keywords: test, summary" in summary


### PR DESCRIPTION
## Summary
- Implement CSV parser with column type detection (string, int, float, date)
- Implement DCAT parser supporting JSON-LD and Turtle formats
- Extract metadata: title, description, publisher, keywords, temporal/spatial coverage
- Create unified data models using dataclasses
- Handle encoding issues (UTF-8, ISO-8859-1)

## Test plan
- [x] Unit tests for CSV parser
- [x] Unit tests for DCAT parser
- [x] Tests for edge cases and error handling

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)