### PR TITLE
Add LangGraph mapping proposal flow with state management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Thumbs.db
 *.output.ttl
 temp/
 tmp/
+data/

--- a/src/ogd_to_lod/graph/__init__.py
+++ b/src/ogd_to_lod/graph/__init__.py
@@ -1,1 +1,34 @@
 """LangGraph conversation flow management."""
+
+from ogd_to_lod.graph.state import (
+    DimensionProposal,
+    FlowState,
+    GraphState,
+    MappingProposal,
+    MeasureProposal,
+    UserIntent,
+)
+from ogd_to_lod.graph.flow import MappingFlow
+from ogd_to_lod.graph.nodes import (
+    analyze_node,
+    handle_user_input,
+    init_node,
+    propose_node,
+)
+
+__all__ = [
+    # State
+    "DimensionProposal",
+    "FlowState",
+    "GraphState",
+    "MappingProposal",
+    "MeasureProposal",
+    "UserIntent",
+    # Flow
+    "MappingFlow",
+    # Nodes
+    "analyze_node",
+    "handle_user_input",
+    "init_node",
+    "propose_node",
+]

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -1,0 +1,231 @@
+"""LangGraph flow definition for the mapping conversation."""
+
+from typing import Any, Callable
+from langgraph.graph import StateGraph, END
+
+from ogd_to_lod.ai import AIService
+from ogd_to_lod.config import Config
+from ogd_to_lod.logging import get_logger
+
+from .state import FlowState, GraphState
+from .nodes import init_node, analyze_node, propose_node, handle_user_input
+
+
+logger = get_logger(__name__)
+
+
+class MappingFlow:
+    """Orchestrates the mapping conversation flow using LangGraph.
+
+    This class manages the state machine for the CSV to RML mapping process,
+    handling state transitions and user interactions.
+    """
+
+    def __init__(self, config: Config, ai_service: AIService | None = None):
+        """Initialize the mapping flow.
+
+        Args:
+            config: Application configuration.
+            ai_service: Optional AI service instance. If not provided,
+                one will be created from config.
+        """
+        self._config = config
+        self._ai_service = ai_service or AIService(config.azure)
+        self._graph = self._build_graph()
+        self._state = GraphState()
+
+    def _build_graph(self) -> StateGraph:
+        """Build the LangGraph state machine.
+
+        Returns:
+            Configured StateGraph instance.
+        """
+        # Create state graph
+        graph = StateGraph(dict)
+
+        # Add nodes
+        graph.add_node("init", self._wrap_init)
+        graph.add_node("analyze", self._wrap_analyze)
+        graph.add_node("propose", self._wrap_propose)
+        graph.add_node("wait_for_input", self._wait_for_input)
+        graph.add_node("process_input", self._wrap_process_input)
+        graph.add_node("error", self._handle_error)
+
+        # Set entry point
+        graph.set_entry_point("init")
+
+        # Add edges with conditional routing
+        graph.add_conditional_edges(
+            "init",
+            self._route_from_init,
+            {
+                "analyze": "analyze",
+                "error": "error",
+            },
+        )
+
+        graph.add_conditional_edges(
+            "analyze",
+            self._route_from_analyze,
+            {
+                "propose": "propose",
+                "error": "error",
+            },
+        )
+
+        graph.add_edge("propose", "wait_for_input")
+
+        graph.add_conditional_edges(
+            "process_input",
+            self._route_from_process_input,
+            {
+                "generate": END,  # For now, end here (GENERATE is issue #7)
+                "refine": "propose",  # Loop back for refinement
+                "wait": "wait_for_input",  # Wait for more input
+                "error": "error",
+            },
+        )
+
+        graph.add_edge("error", END)
+
+        return graph.compile()
+
+    def _wrap_init(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for init node."""
+        self._state = init_node(self._state, self._config)
+        return self._state.to_dict()
+
+    def _wrap_analyze(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for analyze node."""
+        self._state = analyze_node(self._state, self._config)
+        return self._state.to_dict()
+
+    def _wrap_propose(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for propose node."""
+        self._state = propose_node(self._state, self._ai_service)
+        return self._state.to_dict()
+
+    def _wait_for_input(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Node that waits for user input."""
+        self._state.awaiting_user_input = True
+        return self._state.to_dict()
+
+    def _wrap_process_input(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for processing user input."""
+        if self._state.user_input:
+            self._state = handle_user_input(
+                self._state, self._state.user_input, self._ai_service
+            )
+        return self._state.to_dict()
+
+    def _handle_error(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Handle error state."""
+        logger.error(f"Flow error: {self._state.error_message}")
+        return self._state.to_dict()
+
+    def _route_from_init(self, state_dict: dict[str, Any]) -> str:
+        """Route from INIT state."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        return "analyze"
+
+    def _route_from_analyze(self, state_dict: dict[str, Any]) -> str:
+        """Route from ANALYZE state."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        return "propose"
+
+    def _route_from_process_input(self, state_dict: dict[str, Any]) -> str:
+        """Route based on processed user input."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        if self._state.current_state == FlowState.GENERATE:
+            return "generate"
+        if self._state.current_state == FlowState.REFINE:
+            return "refine"
+        if self._state.awaiting_user_input:
+            return "wait"
+        return "wait"
+
+    @property
+    def state(self) -> GraphState:
+        """Get current flow state."""
+        return self._state
+
+    @property
+    def ai_service(self) -> AIService:
+        """Get the AI service instance."""
+        return self._ai_service
+
+    def start(self, csv_path: str, dcat_path: str | None = None, base_uri: str | None = None) -> GraphState:
+        """Start the mapping flow.
+
+        Args:
+            csv_path: Path to the CSV file.
+            dcat_path: Optional path to DCAT metadata file.
+            base_uri: Optional base URI for generated resources.
+
+        Returns:
+            Current state after initialization and analysis.
+        """
+        logger.info(f"Starting mapping flow for {csv_path}")
+
+        # Set initial state
+        self._state = GraphState(
+            csv_path=csv_path,
+            dcat_path=dcat_path,
+            base_uri=base_uri,
+        )
+
+        # Run until we need user input
+        result = self._graph.invoke(self._state.to_dict())
+
+        return self._state
+
+    def continue_with_input(self, user_input: str) -> GraphState:
+        """Continue the flow with user input.
+
+        Args:
+            user_input: User's response.
+
+        Returns:
+            Updated state after processing input.
+        """
+        logger.info("Continuing flow with user input")
+
+        self._state.user_input = user_input
+        self._state.awaiting_user_input = False
+
+        # Process input and continue
+        self._state = handle_user_input(self._state, user_input, self._ai_service)
+
+        # If approved, we'd transition to GENERATE (issue #7)
+        # For now, if refining, we call propose again
+        if self._state.current_state == FlowState.REFINE:
+            self._state.current_state = FlowState.PROPOSE
+            self._state = propose_node(self._state, self._ai_service)
+
+        return self._state
+
+    def get_proposal_text(self) -> str | None:
+        """Get the current proposal text for display."""
+        return self._state.proposal_text
+
+    def get_parsed_summary(self) -> str | None:
+        """Get the parsed data summary for display."""
+        return self._state.parsed_summary
+
+    def is_awaiting_input(self) -> bool:
+        """Check if flow is waiting for user input."""
+        return self._state.awaiting_user_input
+
+    def is_complete(self) -> bool:
+        """Check if flow has completed."""
+        return self._state.current_state in (FlowState.END, FlowState.ERROR)
+
+    def is_approved(self) -> bool:
+        """Check if mapping has been approved."""
+        return (
+            self._state.mapping_proposal is not None
+            and self._state.mapping_proposal.status == "approved"
+        )

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -1,0 +1,337 @@
+"""Node functions for the LangGraph conversation flow."""
+
+import yaml
+from typing import Any
+
+from ogd_to_lod.ai import AIService, ParsedResponse
+from ogd_to_lod.config import Config
+from ogd_to_lod.logging import get_logger
+from ogd_to_lod.parsers import parse_csv, parse_dcat, CSVParseError, DCATParseError
+
+from .state import (
+    DimensionProposal,
+    FlowState,
+    GraphState,
+    MappingProposal,
+    MeasureProposal,
+    UserIntent,
+)
+
+
+logger = get_logger(__name__)
+
+
+def init_node(state: GraphState, config: Config) -> GraphState:
+    """Initialize the conversation flow.
+
+    Validates that required inputs are provided.
+
+    Args:
+        state: Current graph state.
+        config: Application configuration.
+
+    Returns:
+        Updated state.
+    """
+    logger.info("Entering INIT state")
+
+    # Check required inputs
+    if not state.csv_path:
+        state.error_message = "CSV path is required"
+        state.current_state = FlowState.ERROR
+        return state
+
+    # Set base URI from config if not provided
+    if not state.base_uri:
+        state.base_uri = config.rml.base_uri
+
+    state.add_message(
+        "system",
+        f"Starting mapping for CSV: {state.csv_path}"
+        + (f" with DCAT: {state.dcat_path}" if state.dcat_path else ""),
+    )
+
+    # Transition to ANALYZE
+    state.current_state = FlowState.ANALYZE
+    logger.info("Transitioning to ANALYZE state")
+
+    return state
+
+
+def analyze_node(state: GraphState, config: Config) -> GraphState:
+    """Analyze CSV and DCAT inputs.
+
+    Parses the CSV file and optional DCAT metadata.
+
+    Args:
+        state: Current graph state.
+        config: Application configuration.
+
+    Returns:
+        Updated state with parsed data.
+    """
+    logger.info("Entering ANALYZE state")
+
+    # Parse CSV
+    try:
+        csv_data = parse_csv(state.csv_path)
+        state.csv_schema = {
+            "source": csv_data.source,
+            "columns": [
+                {
+                    "name": col.name,
+                    "type": col.detected_type.value,
+                    "samples": col.sample_values[:3],
+                }
+                for col in csv_data.columns
+            ],
+            "total_rows": csv_data.total_rows,
+            "sample_rows": csv_data.sample_rows[:3],
+        }
+        logger.debug(f"Parsed CSV with {len(csv_data.columns)} columns")
+    except CSVParseError as e:
+        state.error_message = f"Failed to parse CSV: {e}"
+        state.current_state = FlowState.ERROR
+        return state
+
+    # Parse DCAT if provided
+    if state.dcat_path:
+        try:
+            dcat_data = parse_dcat(state.dcat_path)
+            state.dcat_metadata = {
+                "title": dcat_data.title,
+                "description": dcat_data.description,
+                "publisher": dcat_data.publisher,
+                "keywords": dcat_data.keywords,
+                "temporal_coverage": (
+                    {
+                        "start": dcat_data.temporal_coverage.start_date,
+                        "end": dcat_data.temporal_coverage.end_date,
+                    }
+                    if dcat_data.temporal_coverage
+                    else None
+                ),
+                "spatial_coverage": (
+                    {"location": dcat_data.spatial_coverage.location}
+                    if dcat_data.spatial_coverage
+                    else None
+                ),
+            }
+            logger.debug(f"Parsed DCAT: {dcat_data.title}")
+        except DCATParseError as e:
+            logger.warning(f"Failed to parse DCAT: {e}")
+            # DCAT is optional, so we continue
+
+    # Build summary
+    state.parsed_summary = _build_summary(state.csv_schema, state.dcat_metadata)
+
+    # Transition to PROPOSE
+    state.current_state = FlowState.PROPOSE
+    logger.info("Transitioning to PROPOSE state")
+
+    return state
+
+
+def propose_node(state: GraphState, ai_service: AIService) -> GraphState:
+    """Have AI propose a mapping based on analyzed data.
+
+    Args:
+        state: Current graph state.
+        ai_service: AI service for generating proposals.
+
+    Returns:
+        Updated state with mapping proposal.
+    """
+    logger.info("Entering PROPOSE state")
+
+    # Build context for AI
+    context = _build_ai_context(state)
+    ai_service.add_context(context)
+
+    # Ask AI for proposal
+    prompt = """Based on the CSV schema and metadata provided, please propose a mapping structure.
+
+Identify:
+1. Which columns should be dimensions (and their types: temporal, spatial, or categorical)
+2. Which columns should be measures (with units if applicable)
+3. Any hierarchies that should be created
+
+Provide your proposal in YAML format with your explanation."""
+
+    logger.debug("Sending proposal request to AI")
+    response = ai_service.send_message(prompt)
+    parsed = AIService.parse_response(response)
+
+    # Store response
+    state.proposal_text = parsed.text
+    state.add_message("assistant", response)
+
+    # Parse YAML proposal if present
+    yaml_blocks = parsed.get_yaml_blocks()
+    if yaml_blocks:
+        try:
+            proposal_data = yaml.safe_load(yaml_blocks[0])
+            state.mapping_proposal = _parse_proposal(proposal_data)
+            logger.debug(f"Parsed proposal with {len(state.mapping_proposal.dimensions)} dimensions")
+        except yaml.YAMLError as e:
+            logger.warning(f"Failed to parse YAML proposal: {e}")
+            state.mapping_proposal = MappingProposal()
+    else:
+        state.mapping_proposal = MappingProposal()
+
+    # Wait for user confirmation
+    state.awaiting_user_input = True
+    logger.info("Awaiting user input on proposal")
+
+    return state
+
+
+def handle_user_input(state: GraphState, user_input: str, ai_service: AIService) -> GraphState:
+    """Process user input and determine next state.
+
+    Args:
+        state: Current graph state.
+        user_input: User's response.
+        ai_service: AI service for interpreting intent.
+
+    Returns:
+        Updated state with interpreted intent and next state.
+    """
+    logger.info(f"Processing user input: {user_input[:50]}...")
+
+    state.user_input = user_input
+    state.awaiting_user_input = False
+    state.add_message("user", user_input)
+
+    # Use AI to interpret user intent
+    intent_prompt = f"""The user responded to the mapping proposal with: "{user_input}"
+
+Determine their intent. Respond with ONLY one of these words:
+- APPROVE: if they accept the proposal (e.g., "yes", "looks good", "ok", "ship it")
+- REJECT: if they completely reject it
+- OVERRIDE: if they want to change specific aspects
+- QUESTION: if they are asking a question
+
+Your response (one word only):"""
+
+    # Send intent detection as a separate context (don't pollute main conversation)
+    response = ai_service.send_message(intent_prompt)
+    intent_text = response.strip().upper()
+
+    # Map response to intent
+    intent_map = {
+        "APPROVE": UserIntent.APPROVE,
+        "REJECT": UserIntent.REJECT,
+        "OVERRIDE": UserIntent.OVERRIDE,
+        "QUESTION": UserIntent.QUESTION,
+    }
+    state.user_intent = intent_map.get(intent_text, UserIntent.UNKNOWN)
+    logger.debug(f"Detected user intent: {state.user_intent}")
+
+    # Determine next state based on intent
+    if state.user_intent == UserIntent.APPROVE:
+        state.current_state = FlowState.GENERATE
+        if state.mapping_proposal:
+            state.mapping_proposal.status = "approved"
+        logger.info("User approved, transitioning to GENERATE")
+    elif state.user_intent in (UserIntent.OVERRIDE, UserIntent.QUESTION, UserIntent.REJECT):
+        state.current_state = FlowState.REFINE
+        if state.mapping_proposal:
+            state.mapping_proposal.status = "refining"
+        logger.info("User wants changes, transitioning to REFINE")
+    else:
+        # Unknown intent, stay in current state and ask for clarification
+        state.awaiting_user_input = True
+        logger.info("Unknown intent, awaiting clarification")
+
+    return state
+
+
+def _build_summary(csv_schema: dict[str, Any] | None, dcat_metadata: dict[str, Any] | None) -> str:
+    """Build a human-readable summary of parsed data."""
+    lines = []
+
+    if csv_schema:
+        lines.append("## CSV Schema")
+        lines.append(f"Source: {csv_schema.get('source', 'Unknown')}")
+        lines.append(f"Total rows: {csv_schema.get('total_rows', 0)}")
+        lines.append("")
+        lines.append("### Columns")
+        for col in csv_schema.get("columns", []):
+            samples = ", ".join(str(s) for s in col.get("samples", [])[:3])
+            lines.append(f"- **{col['name']}** ({col['type']}): {samples}")
+
+    if dcat_metadata:
+        lines.append("")
+        lines.append("## DCAT Metadata")
+        if dcat_metadata.get("title"):
+            lines.append(f"Title: {dcat_metadata['title']}")
+        if dcat_metadata.get("description"):
+            desc = dcat_metadata["description"][:200]
+            lines.append(f"Description: {desc}...")
+        if dcat_metadata.get("publisher"):
+            lines.append(f"Publisher: {dcat_metadata['publisher']}")
+        if dcat_metadata.get("keywords"):
+            lines.append(f"Keywords: {', '.join(dcat_metadata['keywords'])}")
+
+    return "\n".join(lines)
+
+
+def _build_ai_context(state: GraphState) -> str:
+    """Build context string for AI from state."""
+    lines = [
+        "# Data Context for RML Mapping",
+        "",
+        f"Base URI: {state.base_uri}",
+        "",
+    ]
+
+    if state.csv_schema:
+        lines.append("## CSV Schema")
+        lines.append(f"Total rows: {state.csv_schema.get('total_rows', 0)}")
+        lines.append("")
+        lines.append("Columns:")
+        for col in state.csv_schema.get("columns", []):
+            samples = col.get("samples", [])
+            samples_str = ", ".join(f'"{s}"' for s in samples[:3])
+            lines.append(f"- {col['name']} ({col['type']}): [{samples_str}]")
+
+        lines.append("")
+        lines.append("Sample rows:")
+        for i, row in enumerate(state.csv_schema.get("sample_rows", [])[:3], 1):
+            lines.append(f"  Row {i}: {row}")
+
+    if state.dcat_metadata:
+        lines.append("")
+        lines.append("## DCAT Metadata")
+        for key, value in state.dcat_metadata.items():
+            if value:
+                lines.append(f"- {key}: {value}")
+
+    return "\n".join(lines)
+
+
+def _parse_proposal(data: dict[str, Any]) -> MappingProposal:
+    """Parse YAML proposal data into MappingProposal."""
+    proposal = MappingProposal()
+
+    # Parse dimensions
+    for dim_data in data.get("dimensions", []):
+        dim = DimensionProposal(
+            column=dim_data.get("column", ""),
+            dimension_type=dim_data.get("type", "categorical"),
+            granularity=dim_data.get("granularity"),
+            hierarchy=dim_data.get("hierarchy"),
+        )
+        proposal.dimensions.append(dim)
+
+    # Parse measures
+    for measure_data in data.get("measures", []):
+        measure = MeasureProposal(
+            column=measure_data.get("column", ""),
+            unit=measure_data.get("unit"),
+            aggregation=measure_data.get("aggregation"),
+        )
+        proposal.measures.append(measure)
+
+    return proposal

--- a/src/ogd_to_lod/graph/state.py
+++ b/src/ogd_to_lod/graph/state.py
@@ -1,0 +1,161 @@
+"""LangGraph state schema for the mapping conversation flow."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class FlowState(Enum):
+    """Possible states in the conversation flow."""
+
+    INIT = "init"
+    ANALYZE = "analyze"
+    PROPOSE = "propose"
+    REFINE = "refine"
+    GENERATE = "generate"
+    PREVIEW = "preview"
+    CREATE_PR = "create_pr"
+    END = "end"
+    ERROR = "error"
+
+
+class UserIntent(Enum):
+    """Detected user intent from their response."""
+
+    CONFIRM = "confirm"
+    REJECT = "reject"
+    QUESTION = "question"
+    OVERRIDE = "override"
+    APPROVE = "approve"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class DimensionProposal:
+    """Proposed dimension mapping."""
+
+    column: str
+    dimension_type: str  # temporal, spatial, categorical
+    granularity: str | None = None
+    hierarchy: str | None = None
+
+
+@dataclass
+class MeasureProposal:
+    """Proposed measure mapping."""
+
+    column: str
+    unit: str | None = None
+    aggregation: str | None = None
+
+
+@dataclass
+class MappingProposal:
+    """Complete mapping proposal from AI."""
+
+    dimensions: list[DimensionProposal] = field(default_factory=list)
+    measures: list[MeasureProposal] = field(default_factory=list)
+    status: str = "pending"  # pending, approved, refining
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "dimensions": [
+                {
+                    "column": d.column,
+                    "type": d.dimension_type,
+                    "granularity": d.granularity,
+                    "hierarchy": d.hierarchy,
+                }
+                for d in self.dimensions
+            ],
+            "measures": [
+                {
+                    "column": m.column,
+                    "unit": m.unit,
+                    "aggregation": m.aggregation,
+                }
+                for m in self.measures
+            ],
+            "status": self.status,
+        }
+
+
+@dataclass
+class GraphState:
+    """State for the LangGraph conversation flow.
+
+    This state is passed between nodes and updated as the conversation progresses.
+    """
+
+    # Current state in the flow
+    current_state: FlowState = FlowState.INIT
+
+    # Input paths
+    csv_path: str | None = None
+    dcat_path: str | None = None
+    base_uri: str | None = None
+
+    # Parsed data (populated in ANALYZE state)
+    csv_schema: dict[str, Any] | None = None
+    dcat_metadata: dict[str, Any] | None = None
+    parsed_summary: str | None = None
+
+    # Mapping proposal (populated in PROPOSE state)
+    mapping_proposal: MappingProposal | None = None
+    proposal_text: str | None = None  # AI's explanation
+
+    # User interaction
+    user_input: str | None = None
+    user_intent: UserIntent = UserIntent.UNKNOWN
+    awaiting_user_input: bool = False
+
+    # Generated artifacts (populated in GENERATE state)
+    generated_rml: str | None = None
+    rdf_preview: str | None = None
+    validation_error: str | None = None
+
+    # PR info (populated in CREATE_PR state)
+    pr_url: str | None = None
+    pr_number: int | None = None
+
+    # Conversation history for context
+    messages: list[dict[str, str]] = field(default_factory=list)
+
+    # Error handling
+    error_message: str | None = None
+
+    def add_message(self, role: str, content: str) -> None:
+        """Add a message to the conversation history."""
+        self.messages.append({"role": role, "content": content})
+
+    def get_last_ai_message(self) -> str | None:
+        """Get the last AI message from history."""
+        for msg in reversed(self.messages):
+            if msg["role"] == "assistant":
+                return msg["content"]
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert state to dictionary for serialization."""
+        return {
+            "current_state": self.current_state.value,
+            "csv_path": self.csv_path,
+            "dcat_path": self.dcat_path,
+            "base_uri": self.base_uri,
+            "csv_schema": self.csv_schema,
+            "dcat_metadata": self.dcat_metadata,
+            "parsed_summary": self.parsed_summary,
+            "mapping_proposal": self.mapping_proposal.to_dict() if self.mapping_proposal else None,
+            "proposal_text": self.proposal_text,
+            "user_input": self.user_input,
+            "user_intent": self.user_intent.value,
+            "awaiting_user_input": self.awaiting_user_input,
+            "generated_rml": self.generated_rml,
+            "rdf_preview": self.rdf_preview,
+            "validation_error": self.validation_error,
+            "pr_url": self.pr_url,
+            "pr_number": self.pr_number,
+            "messages": self.messages,
+            "error_message": self.error_message,
+        }

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,406 @@
+"""Tests for the LangGraph conversation flow."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ogd_to_lod.config import Config, GitHubConfig, AzureOpenAIConfig, RMLConfig
+from ogd_to_lod.graph.state import (
+    DimensionProposal,
+    FlowState,
+    GraphState,
+    MappingProposal,
+    MeasureProposal,
+    UserIntent,
+)
+from ogd_to_lod.graph.nodes import (
+    init_node,
+    analyze_node,
+    propose_node,
+    handle_user_input,
+    _build_summary,
+    _build_ai_context,
+    _parse_proposal,
+)
+from ogd_to_lod.graph.flow import MappingFlow
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock configuration."""
+    return Config(
+        github=GitHubConfig(repo="test/repo", token="test-token"),
+        azure=AzureOpenAIConfig(
+            endpoint="https://test.openai.azure.com/",
+            api_key="test-key",
+            deployment="gpt-4",
+        ),
+        rml=RMLConfig(base_uri="https://example.org/"),
+    )
+
+
+@pytest.fixture
+def mock_ai_service():
+    """Create a mock AI service."""
+    service = MagicMock()
+    service.send_message.return_value = """Based on the data, I suggest:
+
+**Dimensions:**
+- `year` - temporal dimension
+- `region` - spatial dimension
+
+**Measures:**
+- `value` - count measure
+
+```yaml
+dimensions:
+  - column: year
+    type: temporal
+    granularity: year
+  - column: region
+    type: spatial
+measures:
+  - column: value
+    unit: count
+```
+"""
+    service.parse_response = MagicMock(side_effect=lambda x: MagicMock(
+        text="Based on the data...",
+        code_blocks=[MagicMock(language="yaml", content="""dimensions:
+  - column: year
+    type: temporal
+    granularity: year
+  - column: region
+    type: spatial
+measures:
+  - column: value
+    unit: count""")],
+        get_yaml_blocks=MagicMock(return_value=["""dimensions:
+  - column: year
+    type: temporal
+    granularity: year
+  - column: region
+    type: spatial
+measures:
+  - column: value
+    unit: count"""]),
+    ))
+    return service
+
+
+class TestGraphState:
+    """Tests for GraphState dataclass."""
+
+    def test_initial_state(self):
+        """Test default state initialization."""
+        state = GraphState()
+        assert state.current_state == FlowState.INIT
+        assert state.csv_path is None
+        assert state.messages == []
+        assert state.awaiting_user_input is False
+
+    def test_add_message(self):
+        """Test adding messages to history."""
+        state = GraphState()
+        state.add_message("user", "Hello")
+        state.add_message("assistant", "Hi there!")
+
+        assert len(state.messages) == 2
+        assert state.messages[0] == {"role": "user", "content": "Hello"}
+        assert state.messages[1] == {"role": "assistant", "content": "Hi there!"}
+
+    def test_get_last_ai_message(self):
+        """Test getting last AI message."""
+        state = GraphState()
+        state.add_message("user", "Question")
+        state.add_message("assistant", "First answer")
+        state.add_message("user", "Follow up")
+        state.add_message("assistant", "Second answer")
+
+        assert state.get_last_ai_message() == "Second answer"
+
+    def test_get_last_ai_message_empty(self):
+        """Test getting last AI message when none exist."""
+        state = GraphState()
+        state.add_message("user", "Question")
+        assert state.get_last_ai_message() is None
+
+    def test_to_dict(self):
+        """Test state serialization."""
+        state = GraphState(
+            csv_path="/path/to/file.csv",
+            base_uri="https://example.org/",
+        )
+        result = state.to_dict()
+
+        assert result["csv_path"] == "/path/to/file.csv"
+        assert result["base_uri"] == "https://example.org/"
+        assert result["current_state"] == "init"
+
+
+class TestMappingProposal:
+    """Tests for MappingProposal dataclass."""
+
+    def test_empty_proposal(self):
+        """Test empty proposal creation."""
+        proposal = MappingProposal()
+        assert proposal.dimensions == []
+        assert proposal.measures == []
+        assert proposal.status == "pending"
+
+    def test_proposal_with_data(self):
+        """Test proposal with dimensions and measures."""
+        proposal = MappingProposal(
+            dimensions=[
+                DimensionProposal(column="year", dimension_type="temporal"),
+                DimensionProposal(column="region", dimension_type="spatial"),
+            ],
+            measures=[
+                MeasureProposal(column="value", unit="count"),
+            ],
+        )
+
+        assert len(proposal.dimensions) == 2
+        assert len(proposal.measures) == 1
+        assert proposal.dimensions[0].column == "year"
+
+    def test_proposal_to_dict(self):
+        """Test proposal serialization."""
+        proposal = MappingProposal(
+            dimensions=[
+                DimensionProposal(column="year", dimension_type="temporal", granularity="year"),
+            ],
+            measures=[
+                MeasureProposal(column="value", unit="count"),
+            ],
+            status="approved",
+        )
+
+        result = proposal.to_dict()
+
+        assert len(result["dimensions"]) == 1
+        assert result["dimensions"][0]["column"] == "year"
+        assert result["dimensions"][0]["type"] == "temporal"
+        assert result["status"] == "approved"
+
+
+class TestInitNode:
+    """Tests for init_node function."""
+
+    def test_init_with_valid_csv(self, mock_config):
+        """Test init with valid CSV path."""
+        state = GraphState(csv_path="/path/to/file.csv")
+        result = init_node(state, mock_config)
+
+        assert result.current_state == FlowState.ANALYZE
+        assert result.base_uri == "https://example.org/"
+
+    def test_init_without_csv(self, mock_config):
+        """Test init without CSV path."""
+        state = GraphState()
+        result = init_node(state, mock_config)
+
+        assert result.current_state == FlowState.ERROR
+        assert "CSV path is required" in result.error_message
+
+    def test_init_with_custom_base_uri(self, mock_config):
+        """Test init preserves custom base URI."""
+        state = GraphState(
+            csv_path="/path/to/file.csv",
+            base_uri="https://custom.org/",
+        )
+        result = init_node(state, mock_config)
+
+        assert result.base_uri == "https://custom.org/"
+
+
+class TestAnalyzeNode:
+    """Tests for analyze_node function."""
+
+    @patch("ogd_to_lod.graph.nodes.parse_csv")
+    def test_analyze_csv_success(self, mock_parse_csv, mock_config):
+        """Test successful CSV analysis."""
+        from ogd_to_lod.parsers.models import CSVData, ColumnInfo, ColumnType
+
+        mock_parse_csv.return_value = CSVData(
+            source="/path/to/file.csv",
+            columns=[
+                ColumnInfo(name="year", detected_type=ColumnType.INTEGER, sample_values=[2020, 2021]),
+                ColumnInfo(name="value", detected_type=ColumnType.FLOAT, sample_values=[1.5, 2.5]),
+            ],
+            sample_rows=[{"year": 2020, "value": 1.5}],
+            total_rows=100,
+        )
+
+        state = GraphState(csv_path="/path/to/file.csv")
+        state.current_state = FlowState.ANALYZE
+
+        result = analyze_node(state, mock_config)
+
+        assert result.current_state == FlowState.PROPOSE
+        assert result.csv_schema is not None
+        assert len(result.csv_schema["columns"]) == 2
+        assert result.parsed_summary is not None
+
+    @patch("ogd_to_lod.graph.nodes.parse_csv")
+    def test_analyze_csv_failure(self, mock_parse_csv, mock_config):
+        """Test CSV analysis failure."""
+        from ogd_to_lod.parsers import CSVParseError
+
+        mock_parse_csv.side_effect = CSVParseError("Invalid CSV")
+
+        state = GraphState(csv_path="/invalid/file.csv")
+        state.current_state = FlowState.ANALYZE
+
+        result = analyze_node(state, mock_config)
+
+        assert result.current_state == FlowState.ERROR
+        assert "Failed to parse CSV" in result.error_message
+
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_build_summary_with_csv(self):
+        """Test summary building with CSV data."""
+        csv_schema = {
+            "source": "/path/to/file.csv",
+            "columns": [
+                {"name": "year", "type": "int", "samples": [2020, 2021]},
+                {"name": "value", "type": "float", "samples": [1.5, 2.5]},
+            ],
+            "total_rows": 100,
+        }
+
+        summary = _build_summary(csv_schema, None)
+
+        assert "CSV Schema" in summary
+        assert "year" in summary
+        assert "value" in summary
+        assert "100" in summary
+
+    def test_build_summary_with_dcat(self):
+        """Test summary building with DCAT metadata."""
+        dcat_metadata = {
+            "title": "Test Dataset",
+            "description": "A test dataset for testing",
+            "publisher": "Test Org",
+            "keywords": ["test", "data"],
+        }
+
+        summary = _build_summary(None, dcat_metadata)
+
+        assert "DCAT Metadata" in summary
+        assert "Test Dataset" in summary
+        assert "Test Org" in summary
+
+    def test_parse_proposal(self):
+        """Test parsing YAML proposal data."""
+        data = {
+            "dimensions": [
+                {"column": "year", "type": "temporal", "granularity": "year"},
+                {"column": "region", "type": "spatial"},
+            ],
+            "measures": [
+                {"column": "value", "unit": "count"},
+            ],
+        }
+
+        proposal = _parse_proposal(data)
+
+        assert len(proposal.dimensions) == 2
+        assert len(proposal.measures) == 1
+        assert proposal.dimensions[0].column == "year"
+        assert proposal.dimensions[0].dimension_type == "temporal"
+        assert proposal.measures[0].unit == "count"
+
+
+class TestUserIntentHandling:
+    """Tests for user intent handling."""
+
+    def test_approve_intent(self, mock_ai_service):
+        """Test handling approval intent."""
+        mock_ai_service.send_message.return_value = "APPROVE"
+
+        state = GraphState(
+            current_state=FlowState.PROPOSE,
+            mapping_proposal=MappingProposal(),
+        )
+
+        result = handle_user_input(state, "looks good", mock_ai_service)
+
+        assert result.user_intent == UserIntent.APPROVE
+        assert result.current_state == FlowState.GENERATE
+        assert result.mapping_proposal.status == "approved"
+
+    def test_override_intent(self, mock_ai_service):
+        """Test handling override intent."""
+        mock_ai_service.send_message.return_value = "OVERRIDE"
+
+        state = GraphState(
+            current_state=FlowState.PROPOSE,
+            mapping_proposal=MappingProposal(),
+        )
+
+        result = handle_user_input(state, "change year to categorical", mock_ai_service)
+
+        assert result.user_intent == UserIntent.OVERRIDE
+        assert result.current_state == FlowState.REFINE
+        assert result.mapping_proposal.status == "refining"
+
+    def test_question_intent(self, mock_ai_service):
+        """Test handling question intent."""
+        mock_ai_service.send_message.return_value = "QUESTION"
+
+        state = GraphState(
+            current_state=FlowState.PROPOSE,
+            mapping_proposal=MappingProposal(),
+        )
+
+        result = handle_user_input(state, "why did you choose temporal?", mock_ai_service)
+
+        assert result.user_intent == UserIntent.QUESTION
+        assert result.current_state == FlowState.REFINE
+
+
+class TestMappingFlow:
+    """Tests for MappingFlow class."""
+
+    @patch("ogd_to_lod.graph.flow.analyze_node")
+    @patch("ogd_to_lod.graph.flow.init_node")
+    def test_flow_initialization(self, mock_init, mock_analyze, mock_config, mock_ai_service):
+        """Test flow initialization."""
+        mock_init.return_value = GraphState(current_state=FlowState.ANALYZE)
+        mock_analyze.return_value = GraphState(current_state=FlowState.PROPOSE)
+
+        flow = MappingFlow(mock_config, mock_ai_service)
+
+        assert flow.state.current_state == FlowState.INIT
+        assert flow.ai_service == mock_ai_service
+
+    def test_is_awaiting_input(self, mock_config, mock_ai_service):
+        """Test is_awaiting_input method."""
+        flow = MappingFlow(mock_config, mock_ai_service)
+        flow._state.awaiting_user_input = True
+
+        assert flow.is_awaiting_input() is True
+
+    def test_is_complete(self, mock_config, mock_ai_service):
+        """Test is_complete method."""
+        flow = MappingFlow(mock_config, mock_ai_service)
+
+        assert flow.is_complete() is False
+
+        flow._state.current_state = FlowState.END
+        assert flow.is_complete() is True
+
+        flow._state.current_state = FlowState.ERROR
+        assert flow.is_complete() is True
+
+    def test_is_approved(self, mock_config, mock_ai_service):
+        """Test is_approved method."""
+        flow = MappingFlow(mock_config, mock_ai_service)
+
+        assert flow.is_approved() is False
+
+        flow._state.mapping_proposal = MappingProposal(status="approved")
+        assert flow.is_approved() is True


### PR DESCRIPTION
## Summary
- Define `GraphState` schema with flow states (INIT, ANALYZE, PROPOSE, REFINE, GENERATE, etc.)
- Implement `MappingProposal` model for dimension/measure proposals
- Add `init_node` for input validation and base URI setup
- Add `analyze_node` for CSV/DCAT parsing and schema extraction
- Add `propose_node` for AI-driven mapping suggestions with YAML parsing
- Add `handle_user_input` for natural language intent detection (APPROVE, OVERRIDE, QUESTION, REJECT)
- Create `MappingFlow` class to orchestrate the LangGraph conversation

## Test plan
- [x] Unit tests for GraphState serialization
- [x] Unit tests for MappingProposal model
- [x] Unit tests for init_node (valid/invalid inputs)
- [x] Unit tests for analyze_node (success/failure cases)
- [x] Unit tests for helper functions
- [x] Unit tests for user intent handling
- [x] Unit tests for MappingFlow class
- [x] All 139 tests passing

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)