### PR TITLE
Add RML validation with RMLMapper support (#5)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,3 +18,10 @@ sparql:
 rml:
   # Base URI pattern for generated resources
   base_uri: "https://ld.stadt-zuerich.ch/statistics/"
+  # RMLMapper configuration for validation
+  # Path to RMLMapper JAR file (can also be set via RMLMAPPER_JAR env var)
+  # rmlmapper_jar: "/path/to/rmlmapper.jar"
+  # Use Docker instead of JAR (set to true if you have Docker installed)
+  rmlmapper_use_docker: false
+  # Docker image to use (only if rmlmapper_use_docker is true)
+  rmlmapper_docker_image: "rmlio/rmlmapper-java:latest"

--- a/src/ogd_to_lod/cli.py
+++ b/src/ogd_to_lod/cli.py
@@ -125,11 +125,40 @@ def main() -> int:
             print("Updated Proposal:")
             print(flow.get_proposal_text())
 
-        # Check if approved
-        if flow.is_approved():
-            print("\nProposal approved!")
-            print("RML generation not yet implemented. See Issue #7.")
-            break
+        # Show generated RML and validation results
+        if flow.has_generated_rml():
+            print("\n" + "=" * 60)
+            print("Generated RML:")
+            print("-" * 60)
+            print(flow.get_generated_rml())
+
+            # Show validation results
+            if flow.is_validated():
+                print("\n" + "=" * 60)
+                print("Validation: PASSED")
+                if flow.has_rdf_preview():
+                    print("\nRDF Preview (first 2000 chars):")
+                    print("-" * 60)
+                    preview = flow.get_rdf_preview()[:2000]
+                    print(preview)
+                    if len(flow.get_rdf_preview()) > 2000:
+                        print("... (truncated)")
+                print("\nReady for PR creation (not yet implemented).")
+                break
+            elif flow.get_validation_error():
+                print("\n" + "=" * 60)
+                print("Validation: FAILED")
+                print(f"Error: {flow.get_validation_error()}")
+                print("\nRefining mapping...")
+                # Show updated proposal after refinement
+                if flow.get_proposal_text():
+                    print("\n" + "=" * 60)
+                    print("Updated Proposal:")
+                    print(flow.get_proposal_text())
+
+        # Check if approved but not yet generated
+        if flow.is_approved() and not flow.has_generated_rml():
+            print("\nProposal approved! Generating RML...")
 
     return 0
 

--- a/src/ogd_to_lod/config.py
+++ b/src/ogd_to_lod/config.py
@@ -39,6 +39,9 @@ class RMLConfig:
     """RML generation configuration."""
 
     base_uri: str = ""
+    rmlmapper_jar: str | None = None
+    rmlmapper_use_docker: bool = False
+    rmlmapper_docker_image: str = "rmlio/rmlmapper-java:latest"
 
 
 @dataclass
@@ -180,8 +183,15 @@ def load_config(config_path: str | Path) -> Config:
         )
 
         rml_data = config_data.get("rml", {})
+        # Support environment variable for RMLMapper JAR path
+        rmlmapper_jar = rml_data.get("rmlmapper_jar") or os.environ.get("RMLMAPPER_JAR")
         rml = RMLConfig(
             base_uri=rml_data.get("base_uri", ""),
+            rmlmapper_jar=rmlmapper_jar,
+            rmlmapper_use_docker=rml_data.get("rmlmapper_use_docker", False),
+            rmlmapper_docker_image=rml_data.get(
+                "rmlmapper_docker_image", "rmlio/rmlmapper-java:latest"
+            ),
         )
 
         # Logging config - can also be set via LOG_LEVEL environment variable

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -8,7 +8,14 @@ from ogd_to_lod.config import Config
 from ogd_to_lod.logging import get_logger
 
 from .state import FlowState, GraphState
-from .nodes import init_node, analyze_node, propose_node, handle_user_input, generate_node
+from .nodes import (
+    init_node,
+    analyze_node,
+    propose_node,
+    handle_user_input,
+    generate_node,
+    validate_node,
+)
 
 
 logger = get_logger(__name__)
@@ -50,6 +57,7 @@ class MappingFlow:
         graph.add_node("wait_for_input", self._wait_for_input)
         graph.add_node("process_input", self._wrap_process_input)
         graph.add_node("generate", self._wrap_generate)
+        graph.add_node("validate", self._wrap_validate)
         graph.add_node("error", self._handle_error)
 
         # Set entry point
@@ -91,7 +99,17 @@ class MappingFlow:
             "generate",
             self._route_from_generate,
             {
-                "preview": END,  # For now, end after generation (PREVIEW is future work)
+                "validate": "validate",  # Proceed to validation
+                "error": "error",
+            },
+        )
+
+        graph.add_conditional_edges(
+            "validate",
+            self._route_from_validate,
+            {
+                "preview": END,  # Validation passed, proceed to preview (end for now)
+                "refine": "propose",  # Validation failed, loop back for refinement
                 "error": "error",
             },
         )
@@ -133,6 +151,18 @@ class MappingFlow:
         self._state = generate_node(self._state, self._ai_service)
         return self._state.to_dict()
 
+    def _wrap_validate(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for validate node."""
+        # Get RMLMapper configuration from config
+        rmlmapper_jar = self._config.rml.rmlmapper_jar
+        use_docker = self._config.rml.rmlmapper_use_docker
+        self._state = validate_node(
+            self._state,
+            rmlmapper_jar=rmlmapper_jar,
+            use_docker=use_docker,
+        )
+        return self._state.to_dict()
+
     def _handle_error(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         """Handle error state."""
         logger.error(f"Flow error: {self._state.error_message}")
@@ -166,6 +196,14 @@ class MappingFlow:
         """Route from GENERATE state."""
         if self._state.current_state == FlowState.ERROR:
             return "error"
+        return "validate"
+
+    def _route_from_validate(self, state_dict: dict[str, Any]) -> str:
+        """Route from VALIDATE state."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        if self._state.current_state == FlowState.REFINE:
+            return "refine"
         return "preview"
 
     @property
@@ -225,6 +263,21 @@ class MappingFlow:
             # User approved - generate RML
             logger.info("User approved mapping, generating RML")
             self._state = generate_node(self._state, self._ai_service)
+
+            # Validate the generated RML
+            if self._state.current_state != FlowState.ERROR:
+                logger.info("Validating generated RML")
+                self._state = validate_node(
+                    self._state,
+                    rmlmapper_jar=self._config.rml.rmlmapper_jar,
+                    use_docker=self._config.rml.rmlmapper_use_docker,
+                )
+
+                # If validation failed, loop back to propose with error context
+                if self._state.current_state == FlowState.REFINE:
+                    logger.info("Validation failed, refining mapping")
+                    self._state = propose_node(self._state, self._ai_service)
+
         elif self._state.current_state == FlowState.REFINE:
             # User wants changes - loop back to propose
             self._state.current_state = FlowState.PROPOSE
@@ -246,7 +299,7 @@ class MappingFlow:
 
     def is_complete(self) -> bool:
         """Check if flow has completed."""
-        return self._state.current_state in (FlowState.END, FlowState.ERROR)
+        return self._state.current_state in (FlowState.END, FlowState.ERROR, FlowState.PREVIEW)
 
     def is_approved(self) -> bool:
         """Check if mapping has been approved."""
@@ -262,3 +315,22 @@ class MappingFlow:
     def has_generated_rml(self) -> bool:
         """Check if RML has been generated."""
         return self._state.generated_rml is not None
+
+    def is_validated(self) -> bool:
+        """Check if RML has been successfully validated."""
+        return (
+            self._state.current_state == FlowState.PREVIEW
+            and self._state.validation_error is None
+        )
+
+    def get_validation_error(self) -> str | None:
+        """Get the validation error message if validation failed."""
+        return self._state.validation_error
+
+    def get_rdf_preview(self) -> str | None:
+        """Get the RDF preview generated from validation."""
+        return self._state.rdf_preview
+
+    def has_rdf_preview(self) -> bool:
+        """Check if an RDF preview is available."""
+        return self._state.rdf_preview is not None

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -8,6 +8,7 @@ from ogd_to_lod.config import Config
 from ogd_to_lod.logging import get_logger
 from ogd_to_lod.parsers import parse_csv, parse_dcat, CSVParseError, DCATParseError
 from ogd_to_lod.rml import RMLGenerator, RMLGenerationError
+from ogd_to_lod.validation import RMLValidator, ValidationResult
 
 from .state import (
     DimensionProposal,
@@ -407,3 +408,100 @@ def _parse_proposal(data: dict[str, Any]) -> MappingProposal:
         proposal.measures.append(measure)
 
     return proposal
+
+
+def validate_node(
+    state: GraphState,
+    rmlmapper_jar: str | None = None,
+    use_docker: bool = False,
+) -> GraphState:
+    """Validate the generated RML mapping.
+
+    Executes the RML mapping against the source CSV to verify it produces
+    valid RDF output. If validation fails, the error is stored and the flow
+    can loop back for refinement.
+
+    Args:
+        state: Current graph state with generated RML.
+        rmlmapper_jar: Path to RMLMapper JAR file (optional).
+        use_docker: Whether to use Docker for RMLMapper.
+
+    Returns:
+        Updated state with validation result.
+    """
+    logger.info("Entering VALIDATE state")
+
+    # Check prerequisites
+    if not state.generated_rml:
+        state.error_message = "No RML to validate"
+        state.current_state = FlowState.ERROR
+        return state
+
+    if not state.csv_path:
+        state.error_message = "CSV path required for validation"
+        state.current_state = FlowState.ERROR
+        return state
+
+    # Initialize validator
+    validator = RMLValidator(rmlmapper_jar=rmlmapper_jar, use_docker=use_docker)
+
+    # Run validation
+    logger.debug(f"Validating RML against {state.csv_path}")
+    result = validator.validate(state.generated_rml, state.csv_path)
+
+    if result.valid:
+        logger.info("RML validation successful")
+
+        # Store RDF preview
+        state.rdf_preview = result.rdf_output
+        state.validation_error = None
+
+        # Log any warnings
+        if result.warnings:
+            for warning in result.warnings:
+                logger.warning(f"Validation warning: {warning}")
+
+        # Add success message
+        if result.rdf_output:
+            # Show a sample of the output (first 1000 chars)
+            preview_sample = result.rdf_output[:1000]
+            if len(result.rdf_output) > 1000:
+                preview_sample += "\n... (truncated)"
+
+            state.add_message(
+                "assistant",
+                f"RML validation successful! Here's a preview of the generated RDF:\n\n"
+                f"```turtle\n{preview_sample}\n```",
+            )
+        else:
+            state.add_message(
+                "assistant",
+                "RML syntax validation successful. "
+                "(Full RDF preview unavailable - RMLMapper not configured)",
+            )
+
+        # Transition to PREVIEW
+        state.current_state = FlowState.PREVIEW
+        logger.info("Transitioning to PREVIEW state")
+
+    else:
+        logger.warning(f"RML validation failed: {result.error_message}")
+
+        # Store validation error
+        state.validation_error = result.error_message
+        state.rdf_preview = None
+
+        # Add error message to conversation
+        state.add_message(
+            "assistant",
+            f"RML validation failed:\n\n{result.error_message}\n\n"
+            "I'll adjust the mapping to fix this issue.",
+        )
+
+        # Transition back to REFINE for correction
+        state.current_state = FlowState.REFINE
+        if state.mapping_proposal:
+            state.mapping_proposal.status = "refining"
+        logger.info("Validation failed, transitioning to REFINE state")
+
+    return state

--- a/src/ogd_to_lod/graph/state.py
+++ b/src/ogd_to_lod/graph/state.py
@@ -13,6 +13,7 @@ class FlowState(Enum):
     PROPOSE = "propose"
     REFINE = "refine"
     GENERATE = "generate"
+    VALIDATE = "validate"
     PREVIEW = "preview"
     CREATE_PR = "create_pr"
     END = "end"

--- a/src/ogd_to_lod/validation/__init__.py
+++ b/src/ogd_to_lod/validation/__init__.py
@@ -1,1 +1,17 @@
 """RML validation using RMLMapper."""
+
+from ogd_to_lod.validation.validator import (
+    RMLValidator,
+    RMLValidationError,
+    RMLMapperNotFoundError,
+    ValidationResult,
+    validate_rml,
+)
+
+__all__ = [
+    "RMLValidator",
+    "RMLValidationError",
+    "RMLMapperNotFoundError",
+    "ValidationResult",
+    "validate_rml",
+]

--- a/src/ogd_to_lod/validation/validator.py
+++ b/src/ogd_to_lod/validation/validator.py
@@ -1,0 +1,443 @@
+"""RML validation using RMLMapper.
+
+This module provides functionality to validate RML mappings by executing them
+against sample CSV data using the RMLMapper tool.
+"""
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from ogd_to_lod.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class RMLValidationError(Exception):
+    """Raised when RML validation fails."""
+
+    pass
+
+
+class RMLMapperNotFoundError(RMLValidationError):
+    """Raised when RMLMapper is not found."""
+
+    pass
+
+
+@dataclass
+class ValidationResult:
+    """Result of RML validation.
+
+    Attributes:
+        valid: Whether the RML is valid.
+        rdf_output: Generated RDF output if valid (Turtle format).
+        error_message: Error message if invalid.
+        warnings: List of warnings from validation.
+    """
+
+    valid: bool
+    rdf_output: str | None = None
+    error_message: str | None = None
+    warnings: list[str] | None = None
+
+
+class RMLValidator:
+    """Validates RML mappings using RMLMapper.
+
+    This validator executes RML mappings against CSV data to verify:
+    1. The RML syntax is valid
+    2. The mapping can be executed against the source data
+    3. Valid RDF is produced
+
+    The validator uses RMLMapper, a Java-based tool that must be available
+    either as a JAR file or via Docker.
+    """
+
+    # Default timeout for RMLMapper execution (in seconds)
+    DEFAULT_TIMEOUT = 60
+
+    def __init__(
+        self,
+        rmlmapper_jar: str | None = None,
+        use_docker: bool = False,
+        docker_image: str = "rmlio/rmlmapper-java:latest",
+    ):
+        """Initialize the validator.
+
+        Args:
+            rmlmapper_jar: Path to RMLMapper JAR file. If not provided,
+                will look for RMLMAPPER_JAR environment variable.
+            use_docker: If True, use Docker instead of JAR file.
+            docker_image: Docker image to use (only if use_docker=True).
+        """
+        self._use_docker = use_docker
+        self._docker_image = docker_image
+
+        if use_docker:
+            self._rmlmapper_jar = None
+        else:
+            self._rmlmapper_jar = rmlmapper_jar or os.environ.get("RMLMAPPER_JAR")
+
+    def validate(
+        self,
+        rml_content: str,
+        csv_path: str,
+        output_format: str = "turtle",
+        timeout: int | None = None,
+    ) -> ValidationResult:
+        """Validate an RML mapping by executing it.
+
+        Args:
+            rml_content: RML mapping in Turtle format.
+            csv_path: Path to the source CSV file.
+            output_format: Output format for RDF (turtle, nquads, jsonld).
+            timeout: Timeout in seconds (default: 60).
+
+        Returns:
+            ValidationResult with validation outcome.
+
+        Raises:
+            RMLMapperNotFoundError: If RMLMapper is not available.
+            RMLValidationError: If validation fails due to configuration issues.
+        """
+        timeout = timeout or self.DEFAULT_TIMEOUT
+
+        # Check if RMLMapper is available
+        if not self._use_docker and not self._rmlmapper_jar:
+            logger.warning("RMLMapper JAR not configured, using syntax-only validation")
+            return self._validate_syntax_only(rml_content)
+
+        # Verify CSV file exists
+        if not Path(csv_path).exists():
+            return ValidationResult(
+                valid=False,
+                error_message=f"CSV file not found: {csv_path}",
+            )
+
+        # Create temporary files for RML and output
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rml_file = Path(tmpdir) / "mapping.ttl"
+            output_file = Path(tmpdir) / "output.ttl"
+
+            # Write RML to temp file
+            rml_file.write_text(rml_content)
+
+            try:
+                if self._use_docker:
+                    result = self._run_docker(
+                        rml_file, csv_path, output_file, output_format, timeout
+                    )
+                else:
+                    result = self._run_jar(
+                        rml_file, csv_path, output_file, output_format, timeout
+                    )
+
+                return result
+
+            except subprocess.TimeoutExpired:
+                return ValidationResult(
+                    valid=False,
+                    error_message=f"RMLMapper timed out after {timeout} seconds",
+                )
+            except FileNotFoundError as e:
+                raise RMLMapperNotFoundError(
+                    f"RMLMapper not found: {e}. "
+                    "Ensure Java is installed and RMLMAPPER_JAR is set."
+                ) from e
+            except Exception as e:
+                logger.error(f"Unexpected error during validation: {e}")
+                return ValidationResult(
+                    valid=False,
+                    error_message=f"Validation error: {e}",
+                )
+
+    def _validate_syntax_only(self, rml_content: str) -> ValidationResult:
+        """Validate RML syntax without executing the mapping.
+
+        This is a fallback when RMLMapper is not available.
+        Uses rdflib to parse the Turtle syntax.
+
+        Args:
+            rml_content: RML mapping in Turtle format.
+
+        Returns:
+            ValidationResult with syntax validation outcome.
+        """
+        try:
+            from rdflib import Graph
+
+            g = Graph()
+            g.parse(data=rml_content, format="turtle")
+
+            # Check for required RML components
+            warnings = []
+
+            # Check for logical source
+            logical_sources = list(
+                g.query(
+                    """
+                SELECT ?source WHERE {
+                    ?map rml:logicalSource ?source .
+                }
+            """
+                )
+            )
+            if not logical_sources:
+                warnings.append("No logical source (rml:logicalSource) found")
+
+            # Check for subject map
+            subject_maps = list(
+                g.query(
+                    """
+                SELECT ?map WHERE {
+                    ?map rr:subjectMap ?sm .
+                }
+            """
+                )
+            )
+            if not subject_maps:
+                warnings.append("No subject map (rr:subjectMap) found")
+
+            return ValidationResult(
+                valid=True,
+                rdf_output=None,
+                warnings=warnings if warnings else None,
+            )
+
+        except Exception as e:
+            return ValidationResult(
+                valid=False,
+                error_message=f"RML syntax error: {e}",
+            )
+
+    def _run_jar(
+        self,
+        rml_file: Path,
+        csv_path: str,
+        output_file: Path,
+        output_format: str,
+        timeout: int,
+    ) -> ValidationResult:
+        """Execute RMLMapper JAR file.
+
+        Args:
+            rml_file: Path to RML mapping file.
+            csv_path: Path to CSV source file.
+            output_file: Path for output file.
+            output_format: Output format.
+            timeout: Timeout in seconds.
+
+        Returns:
+            ValidationResult with execution outcome.
+        """
+        # Build command
+        cmd = [
+            "java",
+            "-jar",
+            self._rmlmapper_jar,
+            "-m",
+            str(rml_file),
+            "-o",
+            str(output_file),
+            "-s",
+            output_format,
+        ]
+
+        logger.debug(f"Running RMLMapper: {' '.join(cmd)}")
+
+        # Execute RMLMapper
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=Path(csv_path).parent,  # Run in CSV directory
+        )
+
+        return self._process_result(result, output_file)
+
+    def _run_docker(
+        self,
+        rml_file: Path,
+        csv_path: str,
+        output_file: Path,
+        output_format: str,
+        timeout: int,
+    ) -> ValidationResult:
+        """Execute RMLMapper via Docker.
+
+        Args:
+            rml_file: Path to RML mapping file.
+            csv_path: Path to CSV source file.
+            output_file: Path for output file.
+            output_format: Output format.
+            timeout: Timeout in seconds.
+
+        Returns:
+            ValidationResult with execution outcome.
+        """
+        csv_dir = Path(csv_path).parent
+        csv_filename = Path(csv_path).name
+
+        # Build Docker command
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{rml_file.parent}:/data",
+            "-v",
+            f"{csv_dir}:/csv:ro",
+            self._docker_image,
+            "-m",
+            "/data/mapping.ttl",
+            "-o",
+            "/data/output.ttl",
+            "-s",
+            output_format,
+        ]
+
+        logger.debug(f"Running RMLMapper via Docker: {' '.join(cmd)}")
+
+        # Execute Docker
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        return self._process_result(result, output_file)
+
+    def _process_result(
+        self, result: subprocess.CompletedProcess, output_file: Path
+    ) -> ValidationResult:
+        """Process RMLMapper execution result.
+
+        Args:
+            result: Subprocess result.
+            output_file: Path to output file.
+
+        Returns:
+            ValidationResult based on execution outcome.
+        """
+        # Check for errors
+        if result.returncode != 0:
+            error_msg = result.stderr or result.stdout or "Unknown error"
+            # Clean up common RMLMapper error messages
+            error_msg = self._clean_error_message(error_msg)
+
+            logger.debug(f"RMLMapper failed: {error_msg}")
+
+            return ValidationResult(
+                valid=False,
+                error_message=error_msg,
+            )
+
+        # Read output
+        try:
+            if output_file.exists():
+                rdf_output = output_file.read_text()
+
+                # Parse warnings from stderr
+                warnings = None
+                if result.stderr:
+                    warning_lines = [
+                        line
+                        for line in result.stderr.splitlines()
+                        if "WARN" in line or "warning" in line.lower()
+                    ]
+                    if warning_lines:
+                        warnings = warning_lines
+
+                return ValidationResult(
+                    valid=True,
+                    rdf_output=rdf_output,
+                    warnings=warnings,
+                )
+            else:
+                return ValidationResult(
+                    valid=False,
+                    error_message="RMLMapper did not produce output",
+                )
+
+        except Exception as e:
+            return ValidationResult(
+                valid=False,
+                error_message=f"Failed to read RMLMapper output: {e}",
+            )
+
+    def _clean_error_message(self, error_msg: str) -> str:
+        """Clean up RMLMapper error messages for better readability.
+
+        Args:
+            error_msg: Raw error message from RMLMapper.
+
+        Returns:
+            Cleaned error message.
+        """
+        # Remove Java stack traces for cleaner messages
+        lines = error_msg.splitlines()
+        cleaned_lines = []
+
+        for line in lines:
+            # Skip stack trace lines
+            if line.strip().startswith("at "):
+                continue
+            if line.strip().startswith("Caused by:"):
+                continue
+            if "java." in line and "Exception" in line:
+                # Keep the exception message but simplify
+                if ":" in line:
+                    cleaned_lines.append(line.split(":")[-1].strip())
+                continue
+            cleaned_lines.append(line)
+
+        return "\n".join(cleaned_lines).strip()
+
+    def is_available(self) -> bool:
+        """Check if RMLMapper is available.
+
+        Returns:
+            True if RMLMapper can be executed.
+        """
+        if self._use_docker:
+            try:
+                result = subprocess.run(
+                    ["docker", "images", "-q", self._docker_image],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                return bool(result.stdout.strip())
+            except Exception:
+                return False
+        else:
+            if not self._rmlmapper_jar:
+                return False
+            return Path(self._rmlmapper_jar).exists()
+
+
+def validate_rml(
+    rml_content: str,
+    csv_path: str,
+    rmlmapper_jar: str | None = None,
+    use_docker: bool = False,
+) -> ValidationResult:
+    """Convenience function to validate RML.
+
+    Args:
+        rml_content: RML mapping in Turtle format.
+        csv_path: Path to the source CSV file.
+        rmlmapper_jar: Path to RMLMapper JAR (optional).
+        use_docker: Use Docker instead of JAR.
+
+    Returns:
+        ValidationResult with validation outcome.
+    """
+    validator = RMLValidator(rmlmapper_jar=rmlmapper_jar, use_docker=use_docker)
+    return validator.validate(rml_content, csv_path)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,394 @@
+"""Tests for RML validation module."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ogd_to_lod.validation import (
+    RMLValidator,
+    RMLValidationError,
+    RMLMapperNotFoundError,
+    ValidationResult,
+    validate_rml,
+)
+from ogd_to_lod.graph.state import FlowState, GraphState, MappingProposal
+from ogd_to_lod.graph.nodes import validate_node
+
+
+# Sample RML for testing
+SAMPLE_RML = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> .
+@prefix cube: <https://cube.link/> .
+@prefix ex: <https://example.org/> .
+
+ex:TriplesMap a rr:TriplesMap ;
+    rml:logicalSource [
+        rml:source "data.csv" ;
+        rml:referenceFormulation ql:CSV
+    ] ;
+    rr:subjectMap [
+        rr:template "https://example.org/observation/{year}/{region}" ;
+        rr:class cube:Observation
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:dimension ;
+        rr:objectMap [
+            rml:reference "year" ;
+            rr:datatype xsd:gYear
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:dimension ;
+        rr:objectMap [
+            rml:reference "region" ;
+            rr:datatype xsd:string
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:measure ;
+        rr:objectMap [
+            rml:reference "value" ;
+            rr:datatype xsd:decimal
+        ]
+    ] .
+"""
+
+# Invalid RML (syntax error)
+INVALID_RML_SYNTAX = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
+This is not valid Turtle syntax!!!
+"""
+
+# RML missing components (valid syntax but missing logical source)
+MINIMAL_RML = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ex: <http://example.org/> .
+
+ex:Something rr:predicateObjectMap [ ] .
+"""
+
+
+@pytest.fixture
+def temp_csv():
+    """Create a temporary CSV file for testing."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False
+    ) as f:
+        f.write("year,region,value\n")
+        f.write("2020,North,100.5\n")
+        f.write("2021,South,200.3\n")
+        yield f.name
+    os.unlink(f.name)
+
+
+class TestRMLValidator:
+    """Tests for RMLValidator class."""
+
+    def test_init_default(self):
+        """Test default initialization."""
+        validator = RMLValidator()
+        assert validator._rmlmapper_jar is None
+        assert validator._use_docker is False
+
+    def test_init_with_jar(self):
+        """Test initialization with JAR path."""
+        validator = RMLValidator(rmlmapper_jar="/path/to/rmlmapper.jar")
+        assert validator._rmlmapper_jar == "/path/to/rmlmapper.jar"
+
+    def test_init_with_docker(self):
+        """Test initialization with Docker."""
+        validator = RMLValidator(use_docker=True)
+        assert validator._use_docker is True
+        assert validator._docker_image == "rmlio/rmlmapper-java:latest"
+
+    def test_init_with_env_var(self, monkeypatch):
+        """Test initialization from environment variable."""
+        monkeypatch.setenv("RMLMAPPER_JAR", "/env/path/rmlmapper.jar")
+        validator = RMLValidator()
+        assert validator._rmlmapper_jar == "/env/path/rmlmapper.jar"
+
+    def test_validate_syntax_only_valid(self):
+        """Test syntax-only validation with valid RML."""
+        validator = RMLValidator()  # No JAR configured
+        result = validator.validate(SAMPLE_RML, "/nonexistent/path.csv")
+
+        assert result.valid is True
+        assert result.rdf_output is None  # No actual RDF generation
+
+    def test_validate_syntax_only_invalid(self):
+        """Test syntax-only validation with invalid RML."""
+        validator = RMLValidator()
+        result = validator.validate(INVALID_RML_SYNTAX, "/nonexistent/path.csv")
+
+        assert result.valid is False
+        assert "syntax error" in result.error_message.lower()
+
+    def test_validate_syntax_only_with_warnings(self):
+        """Test syntax-only validation produces warnings for missing components."""
+        validator = RMLValidator()
+        result = validator.validate(MINIMAL_RML, "/nonexistent/path.csv")
+
+        # Should be valid syntax but may have warnings
+        assert result.valid is True
+        # Warnings about missing logical source or subject map
+        if result.warnings:
+            assert any(
+                "logical source" in w.lower() or "subject map" in w.lower()
+                for w in result.warnings
+            )
+
+    def test_validate_csv_not_found(self, temp_csv):
+        """Test validation fails when CSV doesn't exist."""
+        validator = RMLValidator(rmlmapper_jar="/fake/path.jar")
+        result = validator.validate(SAMPLE_RML, "/nonexistent/data.csv")
+
+        assert result.valid is False
+        assert "not found" in result.error_message.lower()
+
+    @patch("subprocess.run")
+    def test_validate_with_jar_success(self, mock_run, temp_csv):
+        """Test successful validation with JAR."""
+        # Mock successful RMLMapper execution
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+
+            # Need to mock the output file creation
+            with patch.object(Path, "read_text", return_value="<rdf output>"):
+                with patch.object(Path, "exists", return_value=True):
+                    result = validator.validate(SAMPLE_RML, temp_csv)
+
+            assert result.valid is True
+            assert mock_run.called
+        finally:
+            os.unlink(jar_path)
+
+    @patch("subprocess.run")
+    def test_validate_with_jar_failure(self, mock_run, temp_csv):
+        """Test validation failure with JAR."""
+        # Mock failed RMLMapper execution
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="Error: Invalid column reference 'unknown_column'",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            result = validator.validate(SAMPLE_RML, temp_csv)
+
+            assert result.valid is False
+            assert "unknown_column" in result.error_message
+        finally:
+            os.unlink(jar_path)
+
+    @patch("subprocess.run")
+    def test_validate_timeout(self, mock_run, temp_csv):
+        """Test validation timeout handling."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="java", timeout=60)
+
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            result = validator.validate(SAMPLE_RML, temp_csv, timeout=60)
+
+            assert result.valid is False
+            assert "timed out" in result.error_message.lower()
+        finally:
+            os.unlink(jar_path)
+
+    def test_clean_error_message(self):
+        """Test error message cleaning."""
+        validator = RMLValidator()
+
+        # Test with Java stack trace
+        raw_error = """java.lang.RuntimeException: Error processing mapping
+at be.ugent.rml.Executor.execute(Executor.java:123)
+at be.ugent.rml.Main.main(Main.java:45)
+Caused by: java.io.FileNotFoundException: file.csv
+Invalid file path"""
+
+        cleaned = validator._clean_error_message(raw_error)
+
+        # Should not contain stack trace lines
+        assert "at be.ugent" not in cleaned
+        assert "Caused by:" not in cleaned
+        # Should contain the actual error
+        assert "Invalid file path" in cleaned
+
+    def test_is_available_no_jar(self):
+        """Test availability check with no JAR."""
+        validator = RMLValidator()
+        assert validator.is_available() is False
+
+    def test_is_available_with_nonexistent_jar(self):
+        """Test availability check with nonexistent JAR."""
+        validator = RMLValidator(rmlmapper_jar="/nonexistent/path.jar")
+        assert validator.is_available() is False
+
+    def test_is_available_with_existing_jar(self):
+        """Test availability check with existing JAR."""
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            assert validator.is_available() is True
+        finally:
+            os.unlink(jar_path)
+
+
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_valid_result(self):
+        """Test valid result creation."""
+        result = ValidationResult(
+            valid=True,
+            rdf_output="<rdf content>",
+        )
+        assert result.valid is True
+        assert result.rdf_output == "<rdf content>"
+        assert result.error_message is None
+        assert result.warnings is None
+
+    def test_invalid_result(self):
+        """Test invalid result creation."""
+        result = ValidationResult(
+            valid=False,
+            error_message="Something went wrong",
+        )
+        assert result.valid is False
+        assert result.rdf_output is None
+        assert result.error_message == "Something went wrong"
+
+    def test_result_with_warnings(self):
+        """Test result with warnings."""
+        result = ValidationResult(
+            valid=True,
+            warnings=["Warning 1", "Warning 2"],
+        )
+        assert result.valid is True
+        assert len(result.warnings) == 2
+
+
+class TestValidateRMLFunction:
+    """Tests for the validate_rml convenience function."""
+
+    def test_validate_rml_syntax_only(self):
+        """Test convenience function with syntax-only validation."""
+        result = validate_rml(SAMPLE_RML, "/nonexistent/path.csv")
+
+        assert result.valid is True
+
+
+class TestValidateNode:
+    """Tests for the validate_node graph function."""
+
+    def test_validate_node_no_rml(self):
+        """Test validate_node fails without generated RML."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path="/path/to/data.csv",
+        )
+
+        result = validate_node(state)
+
+        assert result.current_state == FlowState.ERROR
+        assert "No RML to validate" in result.error_message
+
+    def test_validate_node_no_csv_path(self):
+        """Test validate_node fails without CSV path."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            generated_rml=SAMPLE_RML,
+        )
+
+        result = validate_node(state)
+
+        assert result.current_state == FlowState.ERROR
+        assert "CSV path required" in result.error_message
+
+    def test_validate_node_syntax_valid(self, temp_csv):
+        """Test validate_node with valid RML syntax."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path=temp_csv,
+            generated_rml=SAMPLE_RML,
+            mapping_proposal=MappingProposal(status="approved"),
+        )
+
+        result = validate_node(state)
+
+        assert result.current_state == FlowState.PREVIEW
+        assert result.validation_error is None
+
+    def test_validate_node_syntax_invalid(self, temp_csv):
+        """Test validate_node with invalid RML syntax."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path=temp_csv,
+            generated_rml=INVALID_RML_SYNTAX,
+            mapping_proposal=MappingProposal(status="approved"),
+        )
+
+        result = validate_node(state)
+
+        assert result.current_state == FlowState.REFINE
+        assert result.validation_error is not None
+        assert result.mapping_proposal.status == "refining"
+
+    def test_validate_node_adds_success_message(self, temp_csv):
+        """Test validate_node adds success message to conversation."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path=temp_csv,
+            generated_rml=SAMPLE_RML,
+            mapping_proposal=MappingProposal(status="approved"),
+        )
+
+        result = validate_node(state)
+
+        # Check that a success message was added
+        assert len(result.messages) > 0
+        last_message = result.messages[-1]
+        assert last_message["role"] == "assistant"
+        assert "validation successful" in last_message["content"].lower()
+
+    def test_validate_node_adds_error_message(self, temp_csv):
+        """Test validate_node adds error message on failure."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path=temp_csv,
+            generated_rml=INVALID_RML_SYNTAX,
+            mapping_proposal=MappingProposal(status="approved"),
+        )
+
+        result = validate_node(state)
+
+        # Check that an error message was added
+        assert len(result.messages) > 0
+        last_message = result.messages[-1]
+        assert last_message["role"] == "assistant"
+        assert "validation failed" in last_message["content"].lower()


### PR DESCRIPTION
## Summary
- Add RMLValidator class with support for RMLMapper JAR, Docker, and syntax-only fallback
- Integrate validation into LangGraph flow (GENERATE → VALIDATE → PREVIEW/REFINE)
- Add configuration options for RMLMapper (JAR path, Docker image)
- Update CLI to display validation results and RDF preview
- Add 25 tests for validation module

## Changes
- **New**: `src/ogd_to_lod/validation/validator.py` - RML validator implementation
- **New**: `tests/test_validation.py` - 25 tests for validation
- **Modified**: Graph flow to include validation step with error feedback loop
- **Modified**: Config to support RMLMapper settings
- **Modified**: CLI to display validation results

## Test plan
- [x] All 180 existing tests pass
- [x] 25 new validation tests pass
- [ ] Manual test with RMLMapper JAR (if available)
- [ ] Manual test with RMLMapper Docker image

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)