### PR TITLE
Add GitHub PR creation for RML mappings (#10)

### DIFF
--- a/src/ogd_to_lod/ai/__init__.py
+++ b/src/ogd_to_lod/ai/__init__.py
@@ -1,6 +1,7 @@
 """AI service integration with Azure OpenAI."""
 
 from ogd_to_lod.ai.service import (
+    DEFAULT_SYSTEM_PROMPT,
     AIService,
     AIServiceError,
     CodeBlock,
@@ -8,7 +9,6 @@ from ogd_to_lod.ai.service import (
     Message,
     ParsedResponse,
     RateLimitExceeded,
-    DEFAULT_SYSTEM_PROMPT,
 )
 
 __all__ = [

--- a/src/ogd_to_lod/ai/service.py
+++ b/src/ogd_to_lod/ai/service.py
@@ -12,9 +12,9 @@ from openai import APIConnectionError, APIStatusError, RateLimitError
 
 from ogd_to_lod.config import AzureOpenAIConfig
 
-
 # Default system prompt for RML mapping assistance
-DEFAULT_SYSTEM_PROMPT = """You are an RDF mapping expert specializing in creating RML (RDF Mapping Language)
+DEFAULT_SYSTEM_PROMPT = """\
+You are an RDF mapping expert specializing in creating RML (RDF Mapping Language) \
 configurations for statistical data cubes.
 
 Your task: Help users transform CSV files into RDF data cubes using:

--- a/src/ogd_to_lod/cli.py
+++ b/src/ogd_to_lod/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 from ogd_to_lod.config import load_config
-from ogd_to_lod.graph import MappingFlow, FlowState
+from ogd_to_lod.graph import FlowState, MappingFlow
 from ogd_to_lod.logging import get_logger
 
 logger = get_logger(__name__)
@@ -94,13 +94,20 @@ def main() -> int:
     # Interactive loop
     while flow.is_awaiting_input() and not flow.is_complete():
         print("\n" + "-" * 60)
+
+        # Show appropriate prompt based on state
+        if flow.is_awaiting_pr_confirmation():
+            prompt = "Create a PR with this mapping? (yes/no): "
+        else:
+            prompt = "Your response (or 'quit' to exit): "
+
         try:
-            user_input = input("Your response (or 'quit' to exit): ").strip()
+            user_input = input(prompt).strip()
         except (EOFError, KeyboardInterrupt):
             print("\nExiting...")
             return 0
 
-        if user_input.lower() in ("quit", "exit", "q"):
+        if user_input.lower() in ("quit", "exit", "q") and not flow.is_awaiting_pr_confirmation():
             print("Exiting...")
             return 0
 
@@ -125,10 +132,28 @@ def main() -> int:
             print("Updated Proposal:")
             print(flow.get_proposal_text())
 
-        # Check if approved
-        if flow.is_approved():
-            print("\nProposal approved!")
-            print("RML generation not yet implemented. See Issue #7.")
+        # Check if RML was generated - show it and await PR confirmation
+        if flow.has_generated_rml() and flow.is_awaiting_pr_confirmation():
+            print("\n" + "=" * 60)
+            print("Generated RML Mapping:")
+            print("-" * 60)
+            print(flow.get_generated_rml())
+            print("-" * 60)
+            continue
+
+        # Check if PR was created
+        if flow.has_created_pr():
+            print("\n" + "=" * 60)
+            print("PR created successfully!")
+            print(f"PR #{flow.get_pr_number()}: {flow.get_pr_url()}")
+            break
+
+        # Check if flow completed (user cancelled PR)
+        if flow.is_complete():
+            if not flow.has_created_pr() and flow.has_generated_rml():
+                print("\n" + "=" * 60)
+                print("RML mapping generated but PR creation was skipped.")
+                print("You can find the generated RML above.")
             break
 
     return 0

--- a/src/ogd_to_lod/github/__init__.py
+++ b/src/ogd_to_lod/github/__init__.py
@@ -1,1 +1,5 @@
 """GitHub integration for PR creation."""
+
+from .service import GitHubError, GitHubService, PRCreationError
+
+__all__ = ["GitHubService", "GitHubError", "PRCreationError"]

--- a/src/ogd_to_lod/github/service.py
+++ b/src/ogd_to_lod/github/service.py
@@ -1,0 +1,253 @@
+"""GitHub service for branch creation and PR management."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from github import Github, GithubException
+from github.Repository import Repository
+
+from ogd_to_lod.config import GitHubConfig
+from ogd_to_lod.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GitHubError(Exception):
+    """Base exception for GitHub operations."""
+
+
+class PRCreationError(GitHubError):
+    """Exception raised when PR creation fails."""
+
+
+@dataclass
+class PRResult:
+    """Result of a PR creation operation."""
+
+    pr_number: int
+    pr_url: str
+    branch_name: str
+
+
+class GitHubService:
+    """Service for GitHub operations including branch and PR management.
+
+    This service handles:
+    - Creating branches for new mappings
+    - Committing RML files to the repository
+    - Creating pull requests with descriptions
+    """
+
+    MAPPINGS_FOLDER = "mappings"
+
+    def __init__(self, config: GitHubConfig):
+        """Initialize the GitHub service.
+
+        Args:
+            config: GitHub configuration with repo and token.
+        """
+        self._config = config
+        self._client = Github(config.token)
+        self._repo: Repository | None = None
+
+    @property
+    def repo(self) -> Repository:
+        """Get the repository object, lazily loaded.
+
+        Returns:
+            Repository object for the configured repo.
+
+        Raises:
+            GitHubError: If repository cannot be accessed.
+        """
+        if self._repo is None:
+            try:
+                self._repo = self._client.get_repo(self._config.repo)
+                logger.debug(f"Connected to repository: {self._config.repo}")
+            except GithubException as e:
+                logger.error(f"Failed to access repository: {e}")
+                raise GitHubError(f"Failed to access repository '{self._config.repo}': {e}")
+        return self._repo
+
+    def create_mapping_pr(
+        self,
+        mapping_name: str,
+        rml_content: str,
+        description: str,
+        base_branch: str = "main",
+    ) -> PRResult:
+        """Create a PR with a new RML mapping.
+
+        Creates a new branch, commits the RML file, and opens a pull request.
+
+        Args:
+            mapping_name: Name for the mapping (used for branch and file names).
+            rml_content: The RML Turtle content to commit.
+            description: Human-readable description for the PR body.
+            base_branch: Branch to create PR against (default: main).
+
+        Returns:
+            PRResult with PR number, URL, and branch name.
+
+        Raises:
+            PRCreationError: If any step of PR creation fails.
+        """
+        # Sanitize mapping name for use in branch and file names
+        safe_name = self._sanitize_name(mapping_name)
+        branch_name = f"mapping/{safe_name}"
+        file_path = f"{self.MAPPINGS_FOLDER}/{safe_name}.ttl"
+
+        logger.info(f"Creating PR for mapping: {mapping_name}")
+        logger.debug(f"Branch: {branch_name}, File: {file_path}")
+
+        try:
+            # Get the base branch reference
+            base_ref = self.repo.get_branch(base_branch)
+            base_sha = base_ref.commit.sha
+            logger.debug(f"Base branch {base_branch} at SHA: {base_sha[:8]}")
+
+            # Create new branch
+            self._create_branch(branch_name, base_sha)
+
+            # Commit the RML file
+            commit_message = f"Add RML mapping: {mapping_name}"
+            self._commit_file(branch_name, file_path, rml_content, commit_message)
+
+            # Create the PR
+            pr = self._create_pr(
+                title=f"Add mapping: {mapping_name}",
+                body=description,
+                head=branch_name,
+                base=base_branch,
+            )
+
+            logger.info(f"Created PR #{pr.number}: {pr.html_url}")
+
+            return PRResult(
+                pr_number=pr.number,
+                pr_url=pr.html_url,
+                branch_name=branch_name,
+            )
+
+        except GithubException as e:
+            logger.error(f"GitHub API error during PR creation: {e}")
+            raise PRCreationError(f"Failed to create PR: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error during PR creation: {e}")
+            raise PRCreationError(f"Failed to create PR: {e}")
+
+    def _create_branch(self, branch_name: str, base_sha: str) -> None:
+        """Create a new branch from a base commit.
+
+        Args:
+            branch_name: Name for the new branch.
+            base_sha: SHA of the commit to branch from.
+
+        Raises:
+            GithubException: If branch creation fails.
+        """
+        ref_name = f"refs/heads/{branch_name}"
+
+        # Check if branch already exists
+        try:
+            existing = self.repo.get_git_ref(f"heads/{branch_name}")
+            logger.warning(f"Branch {branch_name} already exists, updating to new base")
+            existing.edit(sha=base_sha)
+        except GithubException:
+            # Branch doesn't exist, create it
+            self.repo.create_git_ref(ref=ref_name, sha=base_sha)
+            logger.debug(f"Created branch: {branch_name}")
+
+    def _commit_file(
+        self,
+        branch_name: str,
+        file_path: str,
+        content: str,
+        message: str,
+    ) -> None:
+        """Commit a file to a branch.
+
+        Args:
+            branch_name: Branch to commit to.
+            file_path: Path for the file in the repository.
+            content: File content.
+            message: Commit message.
+
+        Raises:
+            GithubException: If commit fails.
+        """
+        try:
+            # Check if file already exists
+            existing_file = self.repo.get_contents(file_path, ref=branch_name)
+            # Update existing file
+            self.repo.update_file(
+                path=file_path,
+                message=message,
+                content=content,
+                sha=existing_file.sha,
+                branch=branch_name,
+            )
+            logger.debug(f"Updated file: {file_path}")
+        except GithubException:
+            # File doesn't exist, create it
+            self.repo.create_file(
+                path=file_path,
+                message=message,
+                content=content,
+                branch=branch_name,
+            )
+            logger.debug(f"Created file: {file_path}")
+
+    def _create_pr(
+        self,
+        title: str,
+        body: str,
+        head: str,
+        base: str,
+    ) -> Any:
+        """Create a pull request.
+
+        Args:
+            title: PR title.
+            body: PR description body.
+            head: Head branch name.
+            base: Base branch name.
+
+        Returns:
+            The created PullRequest object.
+
+        Raises:
+            GithubException: If PR creation fails.
+        """
+        pr = self.repo.create_pull(
+            title=title,
+            body=body,
+            head=head,
+            base=base,
+        )
+        return pr
+
+    def _sanitize_name(self, name: str) -> str:
+        """Sanitize a name for use in branch and file names.
+
+        Args:
+            name: Original name.
+
+        Returns:
+            Sanitized name with only alphanumeric characters and hyphens.
+        """
+        # Replace spaces and underscores with hyphens
+        sanitized = name.replace(" ", "-").replace("_", "-")
+        # Remove any characters that aren't alphanumeric or hyphens
+        sanitized = "".join(c for c in sanitized if c.isalnum() or c == "-")
+        # Remove consecutive hyphens
+        while "--" in sanitized:
+            sanitized = sanitized.replace("--", "-")
+        # Remove leading/trailing hyphens
+        sanitized = sanitized.strip("-")
+        # Lowercase
+        sanitized = sanitized.lower()
+        # Ensure it's not empty
+        if not sanitized:
+            sanitized = "mapping"
+        return sanitized

--- a/src/ogd_to_lod/graph/__init__.py
+++ b/src/ogd_to_lod/graph/__init__.py
@@ -1,5 +1,15 @@
 """LangGraph conversation flow management."""
 
+from ogd_to_lod.graph.flow import MappingFlow
+from ogd_to_lod.graph.nodes import (
+    analyze_node,
+    create_pr_node,
+    generate_node,
+    handle_user_input,
+    init_node,
+    preview_node,
+    propose_node,
+)
 from ogd_to_lod.graph.state import (
     DimensionProposal,
     FlowState,
@@ -7,14 +17,6 @@ from ogd_to_lod.graph.state import (
     MappingProposal,
     MeasureProposal,
     UserIntent,
-)
-from ogd_to_lod.graph.flow import MappingFlow
-from ogd_to_lod.graph.nodes import (
-    analyze_node,
-    generate_node,
-    handle_user_input,
-    init_node,
-    propose_node,
 )
 
 __all__ = [
@@ -29,8 +31,10 @@ __all__ = [
     "MappingFlow",
     # Nodes
     "analyze_node",
+    "create_pr_node",
     "generate_node",
     "handle_user_input",
     "init_node",
+    "preview_node",
     "propose_node",
 ]

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -1,15 +1,23 @@
 """LangGraph flow definition for the mapping conversation."""
 
-from typing import Any, Callable
-from langgraph.graph import StateGraph, END
+from typing import Any
+
+from langgraph.graph import END, StateGraph
 
 from ogd_to_lod.ai import AIService
 from ogd_to_lod.config import Config
 from ogd_to_lod.logging import get_logger
 
-from .state import FlowState, GraphState
-from .nodes import init_node, analyze_node, propose_node, handle_user_input, generate_node
-
+from .nodes import (
+    analyze_node,
+    create_pr_node,
+    generate_node,
+    handle_user_input,
+    init_node,
+    preview_node,
+    propose_node,
+)
+from .state import FlowState, GraphState, UserIntent
 
 logger = get_logger(__name__)
 
@@ -50,6 +58,10 @@ class MappingFlow:
         graph.add_node("wait_for_input", self._wait_for_input)
         graph.add_node("process_input", self._wrap_process_input)
         graph.add_node("generate", self._wrap_generate)
+        graph.add_node("preview", self._wrap_preview)
+        graph.add_node("wait_for_pr_confirmation", self._wait_for_pr_confirmation)
+        graph.add_node("process_pr_confirmation", self._wrap_process_pr_confirmation)
+        graph.add_node("create_pr", self._wrap_create_pr)
         graph.add_node("error", self._handle_error)
 
         # Set entry point
@@ -91,7 +103,29 @@ class MappingFlow:
             "generate",
             self._route_from_generate,
             {
-                "preview": END,  # For now, end after generation (PREVIEW is future work)
+                "preview": "preview",
+                "error": "error",
+            },
+        )
+
+        graph.add_edge("preview", "wait_for_pr_confirmation")
+
+        graph.add_conditional_edges(
+            "process_pr_confirmation",
+            self._route_from_pr_confirmation,
+            {
+                "create_pr": "create_pr",
+                "end": END,
+                "wait": "wait_for_pr_confirmation",
+                "error": "error",
+            },
+        )
+
+        graph.add_conditional_edges(
+            "create_pr",
+            self._route_from_create_pr,
+            {
+                "end": END,
                 "error": "error",
             },
         )
@@ -133,6 +167,39 @@ class MappingFlow:
         self._state = generate_node(self._state, self._ai_service)
         return self._state.to_dict()
 
+    def _wrap_preview(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for preview node."""
+        self._state = preview_node(self._state)
+        return self._state.to_dict()
+
+    def _wait_for_pr_confirmation(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Node that waits for PR creation confirmation."""
+        self._state.awaiting_user_input = True
+        return self._state.to_dict()
+
+    def _wrap_process_pr_confirmation(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for processing PR confirmation input."""
+        if self._state.user_input:
+            user_input = self._state.user_input.lower().strip()
+            if user_input in ("yes", "y", "ok", "create", "create pr", "sure", "proceed"):
+                self._state.user_intent = UserIntent.APPROVE
+                self._state.current_state = FlowState.CREATE_PR
+                logger.info("User approved PR creation")
+            elif user_input in ("no", "n", "cancel", "skip", "exit", "quit"):
+                self._state.user_intent = UserIntent.REJECT
+                self._state.current_state = FlowState.END
+                logger.info("User cancelled PR creation")
+            else:
+                # Unknown response, ask again
+                self._state.awaiting_user_input = True
+                logger.info("Unknown response, awaiting clarification")
+        return self._state.to_dict()
+
+    def _wrap_create_pr(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for create PR node."""
+        self._state = create_pr_node(self._state, self._config)
+        return self._state.to_dict()
+
     def _handle_error(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         """Handle error state."""
         logger.error(f"Flow error: {self._state.error_message}")
@@ -168,6 +235,24 @@ class MappingFlow:
             return "error"
         return "preview"
 
+    def _route_from_pr_confirmation(self, state_dict: dict[str, Any]) -> str:
+        """Route based on PR confirmation response."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        if self._state.current_state == FlowState.CREATE_PR:
+            return "create_pr"
+        if self._state.current_state == FlowState.END:
+            return "end"
+        if self._state.awaiting_user_input:
+            return "wait"
+        return "wait"
+
+    def _route_from_create_pr(self, state_dict: dict[str, Any]) -> str:
+        """Route from CREATE_PR state."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        return "end"
+
     @property
     def state(self) -> GraphState:
         """Get current flow state."""
@@ -178,7 +263,12 @@ class MappingFlow:
         """Get the AI service instance."""
         return self._ai_service
 
-    def start(self, csv_path: str, dcat_path: str | None = None, base_uri: str | None = None) -> GraphState:
+    def start(
+        self,
+        csv_path: str,
+        dcat_path: str | None = None,
+        base_uri: str | None = None,
+    ) -> GraphState:
         """Start the mapping flow.
 
         Args:
@@ -199,7 +289,7 @@ class MappingFlow:
         )
 
         # Run until we need user input
-        result = self._graph.invoke(self._state.to_dict())
+        self._graph.invoke(self._state.to_dict())
 
         return self._state
 
@@ -217,7 +307,11 @@ class MappingFlow:
         self._state.user_input = user_input
         self._state.awaiting_user_input = False
 
-        # Process input and continue
+        # Handle PR confirmation if in PREVIEW state
+        if self._state.current_state == FlowState.PREVIEW:
+            return self._handle_pr_confirmation(user_input)
+
+        # Process input for proposal states
         self._state = handle_user_input(self._state, user_input, self._ai_service)
 
         # Handle state transitions based on user intent
@@ -225,10 +319,50 @@ class MappingFlow:
             # User approved - generate RML
             logger.info("User approved mapping, generating RML")
             self._state = generate_node(self._state, self._ai_service)
+
+            # If generation successful, move to PREVIEW
+            if self._state.current_state == FlowState.PREVIEW:
+                self._state = preview_node(self._state)
+
         elif self._state.current_state == FlowState.REFINE:
             # User wants changes - loop back to propose
             self._state.current_state = FlowState.PROPOSE
             self._state = propose_node(self._state, self._ai_service)
+
+        return self._state
+
+    def _handle_pr_confirmation(self, user_input: str) -> GraphState:
+        """Handle user confirmation for PR creation.
+
+        Args:
+            user_input: User's response.
+
+        Returns:
+            Updated state after processing PR confirmation.
+        """
+        user_input_lower = user_input.lower().strip()
+        self._state.add_message("user", user_input)
+
+        if user_input_lower in ("yes", "y", "ok", "create", "create pr", "sure", "proceed"):
+            self._state.user_intent = UserIntent.APPROVE
+            logger.info("User approved PR creation")
+            self._state = create_pr_node(self._state, self._config)
+        elif user_input_lower in ("no", "n", "cancel", "skip", "exit", "quit"):
+            self._state.user_intent = UserIntent.REJECT
+            self._state.current_state = FlowState.END
+            self._state.add_message(
+                "assistant",
+                "PR creation cancelled. RML mapping has been generated but not committed."
+            )
+            logger.info("User cancelled PR creation")
+        else:
+            # Unknown response, ask for clarification
+            self._state.awaiting_user_input = True
+            self._state.add_message(
+                "assistant",
+                "Please respond with 'yes' to create a PR or 'no' to skip PR creation."
+            )
+            logger.info("Unknown response, awaiting clarification")
 
         return self._state
 
@@ -262,3 +396,22 @@ class MappingFlow:
     def has_generated_rml(self) -> bool:
         """Check if RML has been generated."""
         return self._state.generated_rml is not None
+
+    def is_awaiting_pr_confirmation(self) -> bool:
+        """Check if flow is waiting for PR creation confirmation."""
+        return (
+            self._state.current_state == FlowState.PREVIEW
+            and self._state.awaiting_user_input
+        )
+
+    def has_created_pr(self) -> bool:
+        """Check if PR has been created."""
+        return self._state.pr_url is not None
+
+    def get_pr_url(self) -> str | None:
+        """Get the URL of the created PR."""
+        return self._state.pr_url
+
+    def get_pr_number(self) -> int | None:
+        """Get the number of the created PR."""
+        return self._state.pr_number

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -1,13 +1,15 @@
 """Node functions for the LangGraph conversation flow."""
 
-import yaml
 from typing import Any
 
-from ogd_to_lod.ai import AIService, ParsedResponse
+import yaml
+
+from ogd_to_lod.ai import AIService
 from ogd_to_lod.config import Config
+from ogd_to_lod.github import GitHubService, PRCreationError
 from ogd_to_lod.logging import get_logger
-from ogd_to_lod.parsers import parse_csv, parse_dcat, CSVParseError, DCATParseError
-from ogd_to_lod.rml import RMLGenerator, RMLGenerationError
+from ogd_to_lod.parsers import CSVParseError, DCATParseError, parse_csv, parse_dcat
+from ogd_to_lod.rml import RMLGenerationError, RMLGenerator
 
 from .state import (
     DimensionProposal,
@@ -17,7 +19,6 @@ from .state import (
     MeasureProposal,
     UserIntent,
 )
-
 
 logger = get_logger(__name__)
 
@@ -173,7 +174,8 @@ Provide your proposal in YAML format with your explanation."""
         try:
             proposal_data = yaml.safe_load(yaml_blocks[0])
             state.mapping_proposal = _parse_proposal(proposal_data)
-            logger.debug(f"Parsed proposal with {len(state.mapping_proposal.dimensions)} dimensions")
+            num_dims = len(state.mapping_proposal.dimensions)
+            logger.debug(f"Parsed proposal with {num_dims} dimensions")
         except yaml.YAMLError as e:
             logger.warning(f"Failed to parse YAML proposal: {e}")
             state.mapping_proposal = MappingProposal()
@@ -317,6 +319,166 @@ def generate_node(state: GraphState, ai_service: AIService) -> GraphState:
         state.current_state = FlowState.ERROR
 
     return state
+
+
+def preview_node(state: GraphState) -> GraphState:
+    """Display RML preview and wait for user confirmation to create PR.
+
+    Args:
+        state: Current graph state with generated RML.
+
+    Returns:
+        Updated state awaiting user confirmation.
+    """
+    logger.info("Entering PREVIEW state")
+
+    if not state.generated_rml:
+        state.error_message = "No RML generated for preview"
+        state.current_state = FlowState.ERROR
+        return state
+
+    # The CLI will display the RML, we just need to wait for confirmation
+    state.awaiting_user_input = True
+    state.add_message(
+        "assistant",
+        "RML mapping has been generated. Would you like to create a PR with this mapping?"
+    )
+
+    logger.info("Awaiting user confirmation for PR creation")
+
+    return state
+
+
+def create_pr_node(state: GraphState, config: Config) -> GraphState:
+    """Create a GitHub PR with the generated RML mapping.
+
+    Args:
+        state: Current graph state with generated RML and mapping proposal.
+        config: Application configuration with GitHub settings.
+
+    Returns:
+        Updated state with PR information.
+    """
+    logger.info("Entering CREATE_PR state")
+
+    # Validate prerequisites
+    if not state.generated_rml:
+        state.error_message = "No RML generated for PR creation"
+        state.current_state = FlowState.ERROR
+        return state
+
+    if not state.csv_path:
+        state.error_message = "CSV path is required for PR creation"
+        state.current_state = FlowState.ERROR
+        return state
+
+    # Derive mapping name from CSV filename
+    csv_filename = state.csv_path.split("/")[-1].split("\\")[-1]
+    mapping_name = csv_filename.rsplit(".", 1)[0] if "." in csv_filename else csv_filename
+
+    # Build PR description
+    pr_description = _build_pr_description(state, mapping_name)
+
+    # Create the PR
+    try:
+        github_service = GitHubService(config.github)
+        result = github_service.create_mapping_pr(
+            mapping_name=mapping_name,
+            rml_content=state.generated_rml,
+            description=pr_description,
+        )
+
+        state.pr_url = result.pr_url
+        state.pr_number = result.pr_number
+
+        state.add_message(
+            "assistant",
+            f"PR created successfully!\n\nPR #{result.pr_number}: {result.pr_url}"
+        )
+
+        logger.info(f"PR created: #{result.pr_number}")
+
+        # Transition to END state
+        state.current_state = FlowState.END
+        logger.info("Flow completed successfully")
+
+    except PRCreationError as e:
+        logger.error(f"PR creation failed: {e}")
+        state.error_message = f"Failed to create PR: {e}"
+        state.current_state = FlowState.ERROR
+
+    return state
+
+
+def _build_pr_description(state: GraphState, mapping_name: str) -> str:
+    """Build a human-readable PR description.
+
+    Args:
+        state: Current graph state.
+        mapping_name: Name of the mapping.
+
+    Returns:
+        Formatted PR description in markdown.
+    """
+    lines = [
+        f"## RML Mapping: {mapping_name}",
+        "",
+    ]
+
+    # Add data source info
+    if state.csv_path:
+        lines.append(f"**CSV Source:** `{state.csv_path}`")
+    if state.dcat_path:
+        lines.append(f"**DCAT Metadata:** `{state.dcat_path}`")
+    if state.base_uri:
+        lines.append(f"**Base URI:** `{state.base_uri}`")
+    lines.append("")
+
+    # Add DCAT metadata if available
+    if state.dcat_metadata:
+        if state.dcat_metadata.get("title"):
+            lines.append(f"**Dataset Title:** {state.dcat_metadata['title']}")
+        if state.dcat_metadata.get("description"):
+            desc = state.dcat_metadata["description"]
+            if len(desc) > 200:
+                desc = desc[:200] + "..."
+            lines.append(f"**Description:** {desc}")
+        lines.append("")
+
+    # Add mapping summary
+    if state.mapping_proposal:
+        lines.append("### Mapping Structure")
+        lines.append("")
+
+        if state.mapping_proposal.dimensions:
+            lines.append("**Dimensions:**")
+            for dim in state.mapping_proposal.dimensions:
+                dim_str = f"- `{dim.column}` ({dim.dimension_type})"
+                if dim.granularity:
+                    dim_str += f" - granularity: {dim.granularity}"
+                if dim.hierarchy:
+                    dim_str += f" - hierarchy: {dim.hierarchy}"
+                lines.append(dim_str)
+            lines.append("")
+
+        if state.mapping_proposal.measures:
+            lines.append("**Measures:**")
+            for measure in state.mapping_proposal.measures:
+                measure_str = f"- `{measure.column}`"
+                if measure.unit:
+                    measure_str += f" ({measure.unit})"
+                if measure.aggregation:
+                    measure_str += f" - aggregation: {measure.aggregation}"
+                lines.append(measure_str)
+            lines.append("")
+
+    # Add footer
+    lines.extend([
+        "---",
+        "_Generated by [OGD to LOD](https://github.com/redlink-gmbh/ogd-to-lod)_",
+    ])
+
+    return "\n".join(lines)
 
 
 def _build_summary(csv_schema: dict[str, Any] | None, dcat_metadata: dict[str, Any] | None) -> str:

--- a/src/ogd_to_lod/parsers/dcat_parser.py
+++ b/src/ogd_to_lod/parsers/dcat_parser.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 from rdflib import Graph, Namespace
 from rdflib.namespace import DCTERMS, FOAF, RDF
-from rdflib.term import Node, Literal, URIRef
+from rdflib.term import Literal, Node, URIRef
 
 from .models import DCATMetadata, SpatialCoverage, TemporalCoverage
 

--- a/src/ogd_to_lod/rml/__init__.py
+++ b/src/ogd_to_lod/rml/__init__.py
@@ -1,8 +1,8 @@
 """RML generation module for creating RDF Mapping Language configurations."""
 
 from ogd_to_lod.rml.generator import (
-    RMLGenerator,
     RMLGenerationError,
+    RMLGenerator,
     generate_rml,
 )
 from ogd_to_lod.rml.prompts import RML_GENERATION_PROMPT

--- a/src/ogd_to_lod/rml/generator.py
+++ b/src/ogd_to_lod/rml/generator.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from ogd_to_lod.ai import AIService, ParsedResponse
+from ogd_to_lod.ai import AIService
 from ogd_to_lod.logging import get_logger
 from ogd_to_lod.rml.prompts import RML_GENERATION_PROMPT
 
@@ -65,7 +65,7 @@ class RMLGenerator:
             csv_schema=schema_text,
         )
 
-        logger.debug(f"Sending RML generation prompt to AI")
+        logger.debug("Sending RML generation prompt to AI")
 
         try:
             response = self._ai_service.send_message(prompt)

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -1,6 +1,8 @@
 """AI prompts for RML generation."""
 
-RML_GENERATION_PROMPT = """Generate a valid RML (RDF Mapping Language) mapping in Turtle format based on the approved mapping proposal and CSV schema.
+RML_GENERATION_PROMPT = """\
+Generate a valid RML (RDF Mapping Language) mapping in Turtle format \
+based on the approved mapping proposal and CSV schema.
 
 ## Required Prefixes
 Use the following prefixes:
@@ -59,7 +61,8 @@ Do not include explanations outside the code block.
 ```
 """
 
-RML_VALIDATION_PROMPT = """Validate the following RML Turtle mapping for syntactic correctness and completeness.
+RML_VALIDATION_PROMPT = """\
+Validate the following RML Turtle mapping for syntactic correctness and completeness.
 
 Check for:
 1. All required prefixes are defined

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,301 @@
+"""Tests for GitHub integration service."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from github import GithubException
+
+from ogd_to_lod.config import GitHubConfig
+from ogd_to_lod.github import GitHubService, GitHubError, PRCreationError
+
+
+@pytest.fixture
+def github_config():
+    """Create a GitHub configuration for testing."""
+    return GitHubConfig(
+        repo="test-org/test-repo",
+        token="test-token",
+    )
+
+
+@pytest.fixture
+def mock_github():
+    """Create a mock GitHub client."""
+    with patch("ogd_to_lod.github.service.Github") as mock:
+        yield mock
+
+
+class TestGitHubService:
+    """Tests for GitHubService class."""
+
+    def test_init(self, github_config, mock_github):
+        """Test service initialization."""
+        service = GitHubService(github_config)
+
+        mock_github.assert_called_once_with("test-token")
+        assert service._config == github_config
+
+    def test_repo_lazy_loading(self, github_config, mock_github):
+        """Test that repository is lazily loaded."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        service = GitHubService(github_config)
+
+        # Should not have loaded repo yet
+        mock_github.return_value.get_repo.assert_not_called()
+
+        # Access repo property
+        repo = service.repo
+
+        # Should have loaded repo now
+        mock_github.return_value.get_repo.assert_called_once_with("test-org/test-repo")
+        assert repo == mock_repo
+
+    def test_repo_access_error(self, github_config, mock_github):
+        """Test error handling when repository access fails."""
+        mock_github.return_value.get_repo.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        service = GitHubService(github_config)
+
+        with pytest.raises(GitHubError) as exc_info:
+            _ = service.repo
+
+        assert "Failed to access repository" in str(exc_info.value)
+
+    def test_sanitize_name(self, github_config, mock_github):
+        """Test name sanitization for branches and files."""
+        service = GitHubService(github_config)
+
+        # Basic sanitization
+        assert service._sanitize_name("test name") == "test-name"
+        assert service._sanitize_name("test_name") == "test-name"
+        assert service._sanitize_name("Test-Name") == "test-name"
+
+        # Special characters
+        assert service._sanitize_name("test@name#123") == "testname123"
+        assert service._sanitize_name("test--name") == "test-name"
+
+        # Edge cases
+        assert service._sanitize_name("---") == "mapping"
+        assert service._sanitize_name("") == "mapping"
+        assert service._sanitize_name("-test-") == "test"
+
+    def test_create_mapping_pr_success(self, github_config, mock_github):
+        """Test successful PR creation."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        # Mock branch operations
+        mock_branch = MagicMock()
+        mock_branch.commit.sha = "abc123"
+        mock_repo.get_branch.return_value = mock_branch
+
+        # Mock branch doesn't exist
+        mock_repo.get_git_ref.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock file doesn't exist
+        mock_repo.get_contents.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.number = 42
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/42"
+        mock_repo.create_pull.return_value = mock_pr
+
+        service = GitHubService(github_config)
+        result = service.create_mapping_pr(
+            mapping_name="test-mapping",
+            rml_content="@prefix rr: <...> .",
+            description="Test description",
+        )
+
+        assert result.pr_number == 42
+        assert result.pr_url == "https://github.com/test-org/test-repo/pull/42"
+        assert result.branch_name == "mapping/test-mapping"
+
+        # Verify branch was created
+        mock_repo.create_git_ref.assert_called_once_with(
+            ref="refs/heads/mapping/test-mapping",
+            sha="abc123",
+        )
+
+        # Verify file was created
+        mock_repo.create_file.assert_called_once()
+        call_kwargs = mock_repo.create_file.call_args[1]
+        assert call_kwargs["path"] == "mappings/test-mapping.ttl"
+        assert call_kwargs["content"] == "@prefix rr: <...> ."
+        assert call_kwargs["branch"] == "mapping/test-mapping"
+
+        # Verify PR was created
+        mock_repo.create_pull.assert_called_once()
+        pr_kwargs = mock_repo.create_pull.call_args[1]
+        assert pr_kwargs["title"] == "Add mapping: test-mapping"
+        assert pr_kwargs["body"] == "Test description"
+        assert pr_kwargs["head"] == "mapping/test-mapping"
+        assert pr_kwargs["base"] == "main"
+
+    def test_create_mapping_pr_branch_exists(self, github_config, mock_github):
+        """Test PR creation when branch already exists."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        mock_branch = MagicMock()
+        mock_branch.commit.sha = "abc123"
+        mock_repo.get_branch.return_value = mock_branch
+
+        # Mock existing branch
+        mock_existing_ref = MagicMock()
+        mock_repo.get_git_ref.return_value = mock_existing_ref
+
+        # Mock file doesn't exist
+        mock_repo.get_contents.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.number = 43
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/43"
+        mock_repo.create_pull.return_value = mock_pr
+
+        service = GitHubService(github_config)
+        result = service.create_mapping_pr(
+            mapping_name="existing-mapping",
+            rml_content="@prefix rr: <...> .",
+            description="Test description",
+        )
+
+        # Should have updated the existing branch
+        mock_existing_ref.edit.assert_called_once_with(sha="abc123")
+
+        # Should NOT have created a new branch
+        mock_repo.create_git_ref.assert_not_called()
+
+        assert result.pr_number == 43
+
+    def test_create_mapping_pr_file_exists(self, github_config, mock_github):
+        """Test PR creation when file already exists in branch."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        mock_branch = MagicMock()
+        mock_branch.commit.sha = "abc123"
+        mock_repo.get_branch.return_value = mock_branch
+
+        # Mock branch doesn't exist
+        mock_repo.get_git_ref.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock existing file
+        mock_existing_file = MagicMock()
+        mock_existing_file.sha = "file-sha-123"
+        mock_repo.get_contents.return_value = mock_existing_file
+
+        # Mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.number = 44
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/44"
+        mock_repo.create_pull.return_value = mock_pr
+
+        service = GitHubService(github_config)
+        result = service.create_mapping_pr(
+            mapping_name="update-mapping",
+            rml_content="@prefix rr: <...> .",
+            description="Updated mapping",
+        )
+
+        # Should have updated the file
+        mock_repo.update_file.assert_called_once()
+        update_kwargs = mock_repo.update_file.call_args[1]
+        assert update_kwargs["sha"] == "file-sha-123"
+
+        # Should NOT have created a new file
+        mock_repo.create_file.assert_not_called()
+
+        assert result.pr_number == 44
+
+    def test_create_mapping_pr_api_error(self, github_config, mock_github):
+        """Test error handling for API errors during PR creation."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        # Mock API error
+        mock_repo.get_branch.side_effect = GithubException(
+            status=500,
+            data={"message": "Internal Server Error"},
+            headers={},
+        )
+
+        service = GitHubService(github_config)
+
+        with pytest.raises(PRCreationError) as exc_info:
+            service.create_mapping_pr(
+                mapping_name="error-mapping",
+                rml_content="@prefix rr: <...> .",
+                description="Test description",
+            )
+
+        assert "Failed to create PR" in str(exc_info.value)
+
+    def test_create_mapping_pr_custom_base_branch(self, github_config, mock_github):
+        """Test PR creation with custom base branch."""
+        mock_repo = MagicMock()
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        mock_branch = MagicMock()
+        mock_branch.commit.sha = "abc123"
+        mock_repo.get_branch.return_value = mock_branch
+
+        # Mock branch doesn't exist
+        mock_repo.get_git_ref.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock file doesn't exist
+        mock_repo.get_contents.side_effect = GithubException(
+            status=404,
+            data={"message": "Not Found"},
+            headers={},
+        )
+
+        # Mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.number = 45
+        mock_pr.html_url = "https://github.com/test-org/test-repo/pull/45"
+        mock_repo.create_pull.return_value = mock_pr
+
+        service = GitHubService(github_config)
+        result = service.create_mapping_pr(
+            mapping_name="develop-mapping",
+            rml_content="@prefix rr: <...> .",
+            description="Test description",
+            base_branch="develop",
+        )
+
+        # Verify correct base branch was used
+        mock_repo.get_branch.assert_called_with("develop")
+
+        pr_kwargs = mock_repo.create_pull.call_args[1]
+        assert pr_kwargs["base"] == "develop"
+
+        assert result.pr_number == 45


### PR DESCRIPTION
## Summary

- Implements GitHub PR creation functionality for generated RML mappings
- Adds `GitHubService` class using PyGithub for branch and PR management
- Adds `preview_node` and `create_pr_node` to the graph flow state machine
- Updates CLI to display generated RML and handle PR confirmation workflow
- Includes 9 comprehensive tests for the GitHub integration

## Changes

### New Files
- `src/ogd_to_lod/github/service.py` - GitHubService with PR creation logic
- `tests/test_github.py` - Test suite for GitHub integration

### Modified Files
- `src/ogd_to_lod/graph/nodes.py` - Added preview_node and create_pr_node
- `src/ogd_to_lod/graph/flow.py` - Added PREVIEW and CREATE_PR state transitions
- `src/ogd_to_lod/cli.py` - Updated workflow for RML preview and PR confirmation
- Various linting fixes across the codebase

## Test plan

- [x] All 164 tests pass (including 9 new GitHub tests)
- [x] Ruff linting passes
- [ ] Manual test with real GitHub credentials

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)