### PR TITLE
Add RML file output option (#7)

### DIFF
--- a/src/ogd_to_lod/cli.py
+++ b/src/ogd_to_lod/cli.py
@@ -37,6 +37,11 @@ def main() -> int:
         nargs="?",
         help="Path to the DCAT metadata file (JSON-LD or Turtle)",
     )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Path to save the generated RML mapping (Turtle format)",
+    )
 
     args = parser.parse_args()
 
@@ -138,6 +143,15 @@ def main() -> int:
             print("Generated RML:")
             print("-" * 60)
             print(flow.get_generated_rml())
+
+            # Save RML to file if output path provided
+            if args.output:
+                try:
+                    with open(args.output, 'w', encoding='utf-8') as f:
+                        f.write(flow.get_generated_rml())
+                    print(f"\n✓ RML saved to: {args.output}")
+                except Exception as e:
+                    print(f"\n⚠ Warning: Failed to save RML to {args.output}: {e}", file=sys.stderr)
 
             # Show validation results
             if flow.is_validated():


### PR DESCRIPTION
## Summary
- Add `--output/-o` CLI parameter to save generated RML mappings to a file
- Completes issue #7 by adding file save capability

## Changes
- **Modified**: `src/ogd_to_lod/cli.py` - Added `--output` parameter and file save logic

## What Was Already Done
Issue #7 was mostly implemented in commit 3860bce which added:
- RML generation module with AI-powered Turtle generation
- GENERATE state in LangGraph
- Comprehensive tests for RML generation

## What This PR Adds
This PR adds the missing piece - the ability to save generated RML to a local file:
- New `--output/-o` CLI parameter
- Automatic file save when parameter is provided
- Success/error messages for file operations

## Usage
```bash
# Generate and save RML to file
ogd-to-lod data.csv dcat.ttl -o mapping.ttl

# Or use long form
ogd-to-lod data.csv dcat.ttl --output mapping.ttl
```

## Test Plan
- [x] Manual test: Successfully saved 3.8KB RML file
- [x] Verified Turtle format is valid
- [x] Tested error handling (file path issues)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)