### PR TITLE
Add LangSmith tracing integration (#23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4.1
 # WARNING - Something unexpected happened
 # ERROR - Serious problem occurred
 LOG_LEVEL=INFO
+
+# Optional: LangSmith tracing for LLM observability
+# Set LANGSMITH_API_KEY to enable tracing (implicit opt-in)
+# LANGSMITH_API_KEY=lsv2_pt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com  # default, EU endpoint
+# LANGSMITH_PROJECT=ogd-to-lod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 dependencies = [
     "langgraph>=0.2.0",
     "langchain-openai>=0.2.0",
+    "langsmith>=0.1.0",
     "PyGithub>=2.1.0",
     "SPARQLWrapper>=2.0.0",
     "pyyaml>=6.0",

--- a/src/ogd_to_lod/cli.py
+++ b/src/ogd_to_lod/cli.py
@@ -6,6 +6,7 @@ import sys
 from ogd_to_lod.config import load_config
 from ogd_to_lod.graph import FlowState, MappingFlow
 from ogd_to_lod.logging import get_logger
+from ogd_to_lod.tracing import configure_tracing
 
 logger = get_logger(__name__)
 
@@ -54,6 +55,9 @@ def main() -> int:
     except ValueError as e:
         print(f"Error: Invalid configuration: {e}", file=sys.stderr)
         return 1
+
+    # Configure LangSmith tracing (uses env vars loaded by load_config)
+    configure_tracing()
 
     print("OGD to LOD - RML Mapping Tool")
     print(f"Configuration loaded from: {args.config}")

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -1,12 +1,16 @@
 """LangGraph flow definition for the mapping conversation."""
 
+import os
 from typing import Any
 
+import langsmith
+from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, StateGraph
 
 from ogd_to_lod.ai import AIService
 from ogd_to_lod.config import Config
 from ogd_to_lod.logging import get_logger
+from ogd_to_lod.tracing import get_trace_metadata
 
 from .nodes import (
     analyze_node,
@@ -320,8 +324,16 @@ class MappingFlow:
             base_uri=base_uri,
         )
 
+        # Build RunnableConfig with trace metadata
+        metadata = get_trace_metadata(
+            csv_path=csv_path,
+            base_uri=base_uri,
+            flow_state="start",
+        )
+        config = RunnableConfig(metadata=metadata)
+
         # Run until we need user input
-        self._graph.invoke(self._state.to_dict())
+        self._graph.invoke(self._state.to_dict(), config=config)
 
         return self._state
 
@@ -343,6 +355,29 @@ class MappingFlow:
         if self._state.current_state == FlowState.PREVIEW:
             return self._handle_pr_confirmation(user_input)
 
+        metadata = get_trace_metadata(
+            csv_path=self._state.csv_path,
+            base_uri=self._state.base_uri,
+            flow_state=self._state.current_state.value,
+        )
+
+        tracing_enabled = os.environ.get("LANGSMITH_TRACING", "").lower() == "true"
+
+        if tracing_enabled:
+            with langsmith.trace("continue_with_input", metadata=metadata):
+                return self._process_user_input(user_input)
+        else:
+            return self._process_user_input(user_input)
+
+    def _process_user_input(self, user_input: str) -> GraphState:
+        """Process user input and handle state transitions.
+
+        Args:
+            user_input: User's response.
+
+        Returns:
+            Updated state after processing input.
+        """
         # Process input for proposal states
         self._state = handle_user_input(self._state, user_input, self._ai_service)
 

--- a/src/ogd_to_lod/tracing.py
+++ b/src/ogd_to_lod/tracing.py
@@ -1,0 +1,69 @@
+"""LangSmith tracing configuration for LLM call observability."""
+
+import os
+
+from ogd_to_lod.logging import get_logger, get_session_id
+
+logger = get_logger(__name__)
+
+EU_ENDPOINT = "https://eu.api.smith.langchain.com"
+
+
+def configure_tracing() -> bool:
+    """Configure LangSmith tracing if an API key is available.
+
+    When LANGSMITH_API_KEY is set in the environment:
+    - Enables tracing by setting LANGSMITH_TRACING=true
+    - Defaults LANGSMITH_ENDPOINT to the EU endpoint unless already set
+
+    Returns:
+        True if tracing is enabled, False otherwise.
+    """
+    api_key = os.environ.get("LANGSMITH_API_KEY")
+
+    if not api_key:
+        logger.info("LangSmith tracing disabled (LANGSMITH_API_KEY not set)")
+        return False
+
+    os.environ["LANGSMITH_TRACING"] = "true"
+
+    if not os.environ.get("LANGSMITH_ENDPOINT"):
+        os.environ["LANGSMITH_ENDPOINT"] = EU_ENDPOINT
+
+    endpoint = os.environ["LANGSMITH_ENDPOINT"]
+    logger.info(f"LangSmith tracing enabled (endpoint: {endpoint})")
+    return True
+
+
+def get_trace_metadata(
+    *,
+    csv_path: str | None = None,
+    base_uri: str | None = None,
+    flow_state: str | None = None,
+) -> dict[str, str]:
+    """Build metadata dict for attaching to LangSmith runs.
+
+    Args:
+        csv_path: Path to the CSV file being processed.
+        base_uri: Base URI for generated resources.
+        flow_state: Current flow state name.
+
+    Returns:
+        Dictionary of metadata key-value pairs.
+    """
+    metadata: dict[str, str] = {}
+
+    session_id = get_session_id()
+    if session_id:
+        metadata["session_id"] = session_id
+
+    if csv_path:
+        metadata["csv_path"] = csv_path
+
+    if base_uri:
+        metadata["base_uri"] = base_uri
+
+    if flow_state:
+        metadata["flow_state"] = flow_state
+
+    return metadata

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,79 @@
+"""Tests for LangSmith tracing configuration."""
+
+import os
+
+import pytest
+
+from ogd_to_lod.tracing import EU_ENDPOINT, configure_tracing, get_trace_metadata
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Remove LangSmith env vars before each test."""
+    for var in ("LANGSMITH_API_KEY", "LANGSMITH_TRACING", "LANGSMITH_ENDPOINT"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestConfigureTracing:
+    def test_enabled_when_api_key_set(self, monkeypatch):
+        monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_pt_test_key")
+
+        result = configure_tracing()
+
+        assert result is True
+        assert os.environ["LANGSMITH_TRACING"] == "true"
+
+    def test_disabled_when_key_absent(self):
+        result = configure_tracing()
+
+        assert result is False
+        assert os.environ.get("LANGSMITH_TRACING") is None
+
+    def test_eu_endpoint_set_as_default(self, monkeypatch):
+        monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_pt_test_key")
+
+        configure_tracing()
+
+        assert os.environ["LANGSMITH_ENDPOINT"] == EU_ENDPOINT
+
+    def test_existing_endpoint_not_overwritten(self, monkeypatch):
+        custom_endpoint = "https://api.smith.langchain.com"
+        monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_pt_test_key")
+        monkeypatch.setenv("LANGSMITH_ENDPOINT", custom_endpoint)
+
+        configure_tracing()
+
+        assert os.environ["LANGSMITH_ENDPOINT"] == custom_endpoint
+
+
+class TestGetTraceMetadata:
+    def test_returns_all_keys(self, monkeypatch):
+        # Set a session ID via the logging module
+        from ogd_to_lod.logging import set_session_id
+
+        set_session_id("test-session")
+
+        metadata = get_trace_metadata(
+            csv_path="/data/test.csv",
+            base_uri="http://example.org/",
+            flow_state="propose",
+        )
+
+        assert metadata["session_id"] == "test-session"
+        assert metadata["csv_path"] == "/data/test.csv"
+        assert metadata["base_uri"] == "http://example.org/"
+        assert metadata["flow_state"] == "propose"
+
+    def test_omits_none_values(self):
+        metadata = get_trace_metadata()
+
+        assert "csv_path" not in metadata
+        assert "base_uri" not in metadata
+        assert "flow_state" not in metadata
+
+    def test_partial_metadata(self):
+        metadata = get_trace_metadata(csv_path="/data/test.csv")
+
+        assert metadata["csv_path"] == "/data/test.csv"
+        assert "base_uri" not in metadata
+        assert "flow_state" not in metadata


### PR DESCRIPTION
## Summary
- Add LangSmith integration for LLM call tracing with implicit opt-in (enabled when `LANGSMITH_API_KEY` is set)
- Default to EU endpoint (`https://eu.api.smith.langchain.com`) unless overridden
- Attach trace metadata (CSV path, base URI, session ID, flow state) to graph runs

## Test plan
- [x] All 220 existing tests pass
- [x] 7 new tracing tests pass (enable/disable, EU endpoint default, endpoint not overwritten, metadata keys)
- [x] `ogd-to-lod --help` starts without errors (no LangSmith key required)
- [x] Manually verified traces appear in LangSmith when API key is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)