### PR TITLE
Add two-tier RML validation (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ tools/
 temp/
 tmp/
 data/
+
+# Test fixtures (override data/ and *.rml.ttl rules above)
+!tests/data/
+!tests/data/**

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,11 @@ dmypy.json
 .DS_Store
 Thumbs.db
 
+# Claude Code
+.claude/
+
 # Project specific
+tools/
 *.rml.ttl
 *.output.ttl
 temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,12 @@ ogd-to-lod/
 │   ├── parsers/       # CSV and DCAT parsers
 │   ├── ai/            # Azure OpenAI integration
 │   ├── graph/         # LangGraph conversation flow
+│   ├── rml/           # RML generation (prompts, generator)
 │   ├── github/        # GitHub PR creation
-│   └── validation/    # RML validation
+│   └── validation/    # Two-tier RML validation (syntax + RMLMapper)
 ├── tests/             # Test files
 ├── config/            # Configuration files
+├── scripts/           # Utility scripts (RMLMapper setup, worktrees)
 ├── brainstorm.md      # Project requirements
 └── architecture.md    # Technical architecture
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ This tool helps transform Open Government Data (OGD) CSV files into Linked Open 
 ### Prerequisites
 
 - Python 3.11+
-- Java (for RMLMapper validation)
+- Java (optional, for RMLMapper validation)
+
+To set up RMLMapper for full validation:
+```bash
+./scripts/setup-rmlmapper.sh
+```
 
 ### Setup
 
@@ -88,6 +93,8 @@ ogd-to-lod <csv_path> <dcat_path>
 ### Options
 
 - `--config`, `-c`: Path to configuration file (default: `config/config.yaml`)
+- `--output`, `-o`: Path to save the generated RML mapping (Turtle format)
+- `--base-uri`, `-b`: Base URI for generated resources (overrides config)
 - `--help`: Show help message
 
 ## Development
@@ -116,11 +123,13 @@ ogd-to-lod/
 │   ├── parsers/         # CSV and DCAT parsers
 │   ├── ai/              # Azure OpenAI integration
 │   ├── graph/           # LangGraph conversation flow
+│   ├── rml/            # RML generation (prompts, AI-driven generator)
 │   ├── github/          # GitHub PR creation
-│   └── validation/      # RML validation
+│   └── validation/      # Two-tier RML validation (syntax + RMLMapper)
 ├── tests/
 ├── config/
 │   └── config.yaml
+├── scripts/             # Utility scripts (RMLMapper setup, worktrees)
 ├── pyproject.toml
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool helps transform Open Government Data (OGD) CSV files into Linked Open 
 
 1. Analyzing CSV structure and DCAT metadata
 2. Using AI to propose RML mappings targeting cube.link and schema.org vocabularies
-3. Validating mappings with RMLMapper
+3. Validating mappings with RMLMapper (two-tier: syntax check + data-aware execution)
 4. Creating GitHub PRs with the generated mappings
 
 ## Installation
@@ -125,7 +125,7 @@ ogd-to-lod/
 │   ├── graph/           # LangGraph conversation flow
 │   ├── rml/            # RML generation (prompts, AI-driven generator)
 │   ├── github/          # GitHub PR creation
-│   └── validation/      # Two-tier RML validation (syntax + RMLMapper)
+│   └── validation/      # Two-tier RML validation (syntax + RMLMapper + empty-output detection)
 ├── tests/
 ├── config/
 │   └── config.yaml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,8 @@ rml:
   base_uri: "https://ld.stadt-zuerich.ch/statistics/"
   # RMLMapper configuration for validation
   # Path to RMLMapper JAR file (can also be set via RMLMAPPER_JAR env var)
-  # rmlmapper_jar: "/path/to/rmlmapper.jar"
+  # Run scripts/setup-rmlmapper.sh to download automatically
+  rmlmapper_jar: "tools/rmlmapper.jar"
   # Use Docker instead of JAR (set to true if you have Docker installed)
   rmlmapper_use_docker: false
   # Docker image to use (only if rmlmapper_use_docker is true)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ select = ["E", "F", "I", "W"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "integration: tests requiring RMLMapper JAR and Java runtime",
+]

--- a/scripts/setup-rmlmapper.sh
+++ b/scripts/setup-rmlmapper.sh
@@ -12,7 +12,7 @@ JAR_PATH="$TOOLS_DIR/rmlmapper.jar"
 # Check Java is available
 if ! command -v java &> /dev/null; then
     echo "Error: Java is not installed or not in PATH."
-    echo "RMLMapper requires Java 11 or later."
+    echo "RMLMapper requires Java 21 or later."
     echo "Install it with: sudo apt install default-jre  (Debian/Ubuntu)"
     echo "                  brew install openjdk          (macOS)"
     exit 1

--- a/scripts/setup-rmlmapper.sh
+++ b/scripts/setup-rmlmapper.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Download RMLMapper JAR for RML validation
+# Usage: ./scripts/setup-rmlmapper.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TOOLS_DIR="$PROJECT_DIR/tools"
+JAR_PATH="$TOOLS_DIR/rmlmapper.jar"
+
+# Check Java is available
+if ! command -v java &> /dev/null; then
+    echo "Error: Java is not installed or not in PATH."
+    echo "RMLMapper requires Java 11 or later."
+    echo "Install it with: sudo apt install default-jre  (Debian/Ubuntu)"
+    echo "                  brew install openjdk          (macOS)"
+    exit 1
+fi
+
+JAVA_VERSION=$(java -version 2>&1 | head -n 1)
+echo "Found Java: $JAVA_VERSION"
+
+# Create tools directory
+mkdir -p "$TOOLS_DIR"
+
+# Check if JAR already exists
+if [ -f "$JAR_PATH" ]; then
+    echo "RMLMapper JAR already exists at $JAR_PATH"
+    echo "Delete it first if you want to re-download."
+    exit 0
+fi
+
+echo "Downloading latest RMLMapper..."
+
+# Get latest release download URL from GitHub API
+DOWNLOAD_URL=$(curl -s https://api.github.com/repos/RMLio/rmlmapper-java/releases/latest \
+    | grep "browser_download_url.*-all.jar" \
+    | head -n 1 \
+    | cut -d '"' -f 4)
+
+if [ -z "$DOWNLOAD_URL" ]; then
+    echo "Error: Could not determine download URL from GitHub releases."
+    echo "Please download manually from:"
+    echo "  https://github.com/RMLio/rmlmapper-java/releases"
+    exit 1
+fi
+
+echo "  URL: $DOWNLOAD_URL"
+curl -L -o "$JAR_PATH" "$DOWNLOAD_URL"
+
+# Verify download
+if [ ! -f "$JAR_PATH" ]; then
+    echo "Error: Download failed."
+    exit 1
+fi
+
+FILE_SIZE=$(stat -c%s "$JAR_PATH" 2>/dev/null || stat -f%z "$JAR_PATH" 2>/dev/null)
+echo "  Size: $FILE_SIZE bytes"
+
+echo ""
+echo "RMLMapper downloaded successfully to $JAR_PATH"
+echo "Configuration in config/config.yaml is already set to use this path."

--- a/src/ogd_to_lod/graph/__init__.py
+++ b/src/ogd_to_lod/graph/__init__.py
@@ -10,6 +10,7 @@ from ogd_to_lod.graph.nodes import (
     init_node,
     preview_node,
     propose_node,
+    regenerate_node,
     syntax_check_node,
 )
 from ogd_to_lod.graph.state import (
@@ -40,5 +41,6 @@ __all__ = [
     "init_node",
     "preview_node",
     "propose_node",
+    "regenerate_node",
     "syntax_check_node",
 ]

--- a/src/ogd_to_lod/graph/__init__.py
+++ b/src/ogd_to_lod/graph/__init__.py
@@ -2,6 +2,7 @@
 
 from ogd_to_lod.graph.flow import MappingFlow
 from ogd_to_lod.graph.nodes import (
+    MAX_SYNTAX_RETRIES,
     analyze_node,
     create_pr_node,
     generate_node,
@@ -9,6 +10,7 @@ from ogd_to_lod.graph.nodes import (
     init_node,
     preview_node,
     propose_node,
+    syntax_check_node,
 )
 from ogd_to_lod.graph.state import (
     DimensionProposal,
@@ -30,6 +32,7 @@ __all__ = [
     # Flow
     "MappingFlow",
     # Nodes
+    "MAX_SYNTAX_RETRIES",
     "analyze_node",
     "create_pr_node",
     "generate_node",
@@ -37,4 +40,5 @@ __all__ = [
     "init_node",
     "preview_node",
     "propose_node",
+    "syntax_check_node",
 ]

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -17,6 +17,7 @@ from .nodes import (
     init_node,
     preview_node,
     propose_node,
+    regenerate_node,
     syntax_check_node,
     validate_node,
 )
@@ -415,7 +416,7 @@ class MappingFlow:
             if self._state.validation_retry_count < MAX_SYNTAX_RETRIES:
                 # Re-generate with error context
                 self._state.current_state = FlowState.GENERATE
-                self._state = generate_node(self._state, self._ai_service)
+                self._state = regenerate_node(self._state, self._ai_service)
 
                 if self._state.current_state == FlowState.ERROR:
                     return

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -9,6 +9,7 @@ from ogd_to_lod.config import Config
 from ogd_to_lod.logging import get_logger
 
 from .nodes import (
+    MAX_SYNTAX_RETRIES,
     analyze_node,
     create_pr_node,
     generate_node,
@@ -16,6 +17,7 @@ from .nodes import (
     init_node,
     preview_node,
     propose_node,
+    syntax_check_node,
     validate_node,
 )
 from .state import FlowState, GraphState, UserIntent
@@ -352,20 +354,24 @@ class MappingFlow:
             logger.info("User approved mapping, generating RML")
             self._state = generate_node(self._state, self._ai_service)
 
-            # Validate the generated RML
             if self._state.current_state != FlowState.ERROR:
-                logger.info("Validating generated RML")
-                self._state = validate_node(
-                    self._state,
-                    rmlmapper_jar=self._config.rml.rmlmapper_jar,
-                    use_docker=self._config.rml.rmlmapper_use_docker,
-                )
+                # Run Tier 1 (syntax) with auto-retry, then Tier 2 (RMLMapper)
+                self._run_tier1_with_retries()
 
-                # If validation passed, move to PREVIEW
+                # If Tier 1 passed, run Tier 2 (RMLMapper)
+                if self._state.current_state == FlowState.VALIDATE:
+                    logger.info("Tier 1 passed, running Tier 2 (RMLMapper)")
+                    self._state = validate_node(
+                        self._state,
+                        rmlmapper_jar=self._config.rml.rmlmapper_jar,
+                        use_docker=self._config.rml.rmlmapper_use_docker,
+                    )
+
+                # If all validation passed, move to PREVIEW
                 if self._state.current_state == FlowState.PREVIEW:
                     self._state = preview_node(self._state)
 
-                # If validation failed, loop back to propose with error context
+                # If Tier 2 failed, escalate to user via REFINE → PROPOSE
                 elif self._state.current_state == FlowState.REFINE:
                     logger.info("Validation failed, refining mapping")
                     self._state = propose_node(self._state, self._ai_service)
@@ -376,6 +382,59 @@ class MappingFlow:
             self._state = propose_node(self._state, self._ai_service)
 
         return self._state
+
+    def _run_tier1_with_retries(self) -> None:
+        """Run Tier 1 syntax validation with automatic retries.
+
+        On syntax failure, re-runs generate_node with the error in context
+        up to MAX_SYNTAX_RETRIES times. If all retries are exhausted,
+        escalates to the user via REFINE → PROPOSE.
+
+        Mutates self._state in place.
+        """
+        self._state.validation_retry_count = 0
+
+        while self._state.validation_retry_count < MAX_SYNTAX_RETRIES:
+            self._state = syntax_check_node(self._state)
+
+            if self._state.current_state == FlowState.VALIDATE:
+                # Syntax check passed — proceed to Tier 2
+                logger.info(
+                    f"Tier 1 passed on attempt "
+                    f"{self._state.validation_retry_count + 1}"
+                )
+                return
+
+            # Syntax check failed — increment and retry
+            self._state.validation_retry_count += 1
+            logger.warning(
+                f"Tier 1 syntax check failed, retry "
+                f"{self._state.validation_retry_count}/{MAX_SYNTAX_RETRIES}"
+            )
+
+            if self._state.validation_retry_count < MAX_SYNTAX_RETRIES:
+                # Re-generate with error context
+                self._state.current_state = FlowState.GENERATE
+                self._state = generate_node(self._state, self._ai_service)
+
+                if self._state.current_state == FlowState.ERROR:
+                    return
+
+        # Max retries exhausted — escalate to user
+        logger.warning(
+            f"Tier 1 failed after {MAX_SYNTAX_RETRIES} attempts, "
+            "escalating to user"
+        )
+        self._state.add_message(
+            "assistant",
+            f"I was unable to fix the syntax error after "
+            f"{MAX_SYNTAX_RETRIES} attempts. "
+            f"Please help me resolve this issue:\n\n"
+            f"{self._state.validation_error}",
+        )
+        self._state.current_state = FlowState.REFINE
+        if self._state.mapping_proposal:
+            self._state.mapping_proposal.status = "refining"
 
     def _handle_pr_confirmation(self, user_input: str) -> GraphState:
         """Handle user confirmation for PR creation.

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -24,6 +24,9 @@ from .state import (
 
 logger = get_logger(__name__)
 
+# Maximum number of automatic syntax retries before escalating to the user
+MAX_SYNTAX_RETRIES = 3
+
 
 def init_node(state: GraphState, config: Config) -> GraphState:
     """Initialize the conversation flow.
@@ -650,16 +653,55 @@ def _parse_proposal(data: dict[str, Any]) -> MappingProposal:
     return proposal
 
 
+def syntax_check_node(state: GraphState) -> GraphState:
+    """Tier 1: Check RML Turtle syntax using rdflib.
+
+    Fast, cheap check that catches syntax errors. On failure, stores the
+    error in state so the flow can auto-retry via re-generation.
+
+    Args:
+        state: Current graph state with generated RML.
+
+    Returns:
+        Updated state. On success, transitions to VALIDATE (Tier 2).
+        On failure, sets validation_error with the syntax error.
+    """
+    logger.info("Entering SYNTAX_CHECK (Tier 1)")
+
+    if not state.generated_rml:
+        state.error_message = "No RML to validate"
+        state.current_state = FlowState.ERROR
+        return state
+
+    validator = RMLValidator()
+    result = validator.validate_syntax(state.generated_rml)
+
+    if result.valid:
+        logger.info("Tier 1 syntax check passed")
+        state.validation_error = None
+        state.current_state = FlowState.VALIDATE
+    else:
+        logger.warning(f"Tier 1 syntax check failed: {result.error_message}")
+        state.validation_error = result.error_message
+        state.add_message(
+            "assistant",
+            f"RML syntax error (auto-retrying):\n\n{result.error_message}",
+        )
+
+    return state
+
+
 def validate_node(
     state: GraphState,
     rmlmapper_jar: str | None = None,
     use_docker: bool = False,
 ) -> GraphState:
-    """Validate the generated RML mapping.
+    """Tier 2: Validate RML with RMLMapper against sample CSV data.
 
-    Executes the RML mapping against the source CSV to verify it produces
-    valid RDF output. If validation fails, the error is stored and the flow
-    can loop back for refinement.
+    Runs the full RMLMapper validation. On failure, escalates to the user
+    (transitions to REFINE) since data-fit issues need human judgement.
+
+    If RMLMapper is unavailable, gracefully skips to PREVIEW with a note.
 
     Args:
         state: Current graph state with generated RML.
@@ -669,7 +711,7 @@ def validate_node(
     Returns:
         Updated state with validation result.
     """
-    logger.info("Entering VALIDATE state")
+    logger.info("Entering VALIDATE state (Tier 2 — RMLMapper)")
 
     # Check prerequisites
     if not state.generated_rml:
@@ -685,12 +727,12 @@ def validate_node(
     # Initialize validator
     validator = RMLValidator(rmlmapper_jar=rmlmapper_jar, use_docker=use_docker)
 
-    # Run validation
-    logger.debug(f"Validating RML against {state.csv_path}")
-    result = validator.validate(state.generated_rml, state.csv_path)
+    # Run Tier 2 validation with sample CSV
+    logger.debug(f"Validating RML against sample from {state.csv_path}")
+    result = validator.validate_with_rmlmapper(state.generated_rml, state.csv_path)
 
     if result.valid:
-        logger.info("RML validation successful")
+        logger.info("Tier 2 RMLMapper validation successful")
 
         # Store RDF preview
         state.rdf_preview = result.rdf_output
@@ -703,7 +745,6 @@ def validate_node(
 
         # Add success message
         if result.rdf_output:
-            # Show a sample of the output (first 1000 chars)
             preview_sample = result.rdf_output[:1000]
             if len(result.rdf_output) > 1000:
                 preview_sample += "\n... (truncated)"
@@ -714,10 +755,13 @@ def validate_node(
                 f"```turtle\n{preview_sample}\n```",
             )
         else:
+            # RMLMapper was skipped (not configured)
+            note = ""
+            if result.warnings:
+                note = f" ({result.warnings[0]})"
             state.add_message(
                 "assistant",
-                "RML syntax validation successful. "
-                "(Full RDF preview unavailable - RMLMapper not configured)",
+                f"RML syntax validation successful.{note}",
             )
 
         # Transition to PREVIEW
@@ -725,24 +769,28 @@ def validate_node(
         logger.info("Transitioning to PREVIEW state")
 
     else:
-        logger.warning(f"RML validation failed: {result.error_message}")
+        logger.warning(f"Tier 2 validation failed: {result.error_message}")
 
-        # Store validation error
+        # Store validation error with category info
+        error_desc = result.error_message
+        if result.user_friendly_error:
+            error_desc = result.user_friendly_error
+
         state.validation_error = result.error_message
         state.rdf_preview = None
 
-        # Add error message to conversation
+        # Escalate to user (data-fit issues need human judgement)
         state.add_message(
             "assistant",
-            f"RML validation failed:\n\n{result.error_message}\n\n"
-            "I'll adjust the mapping to fix this issue.",
+            f"RML validation failed (RMLMapper):\n\n{error_desc}\n\n"
+            "Please review and suggest how to fix this issue.",
         )
 
-        # Transition back to REFINE for correction
+        # Transition to REFINE — always escalate Tier 2 failures
         state.current_state = FlowState.REFINE
         if state.mapping_proposal:
             state.mapping_proposal.status = "refining"
-        logger.info("Validation failed, transitioning to REFINE state")
+        logger.info("Tier 2 validation failed, transitioning to REFINE state")
 
     return state
 def _robust_parse_yaml_proposal(yaml_content: str) -> MappingProposal | None:

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -691,6 +691,47 @@ def syntax_check_node(state: GraphState) -> GraphState:
     return state
 
 
+def regenerate_node(state: GraphState, ai_service: AIService) -> GraphState:
+    """Regenerate RML by sending the validation error back to the AI.
+
+    Uses the error stored in ``state.validation_error`` (set by
+    ``syntax_check_node``) to give the AI targeted feedback.  Updates
+    ``state.generated_rml`` with the corrected output.
+
+    Args:
+        state: Current graph state with validation_error set.
+        ai_service: AI service for regenerating RML.
+
+    Returns:
+        Updated state with corrected RML.
+    """
+    logger.info("Entering REGENERATE state (error-aware retry)")
+
+    error_message = state.validation_error or "Unknown syntax error"
+
+    try:
+        generator = RMLGenerator(ai_service)
+        rml_content = generator.regenerate_with_error(error_message)
+
+        state.generated_rml = rml_content
+        state.add_message(
+            "assistant",
+            f"Corrected RML mapping:\n\n```turtle\n{rml_content}\n```",
+        )
+
+        logger.info(f"Regenerated RML ({len(rml_content)} characters)")
+
+        # Transition to PREVIEW so syntax_check_node can re-validate
+        state.current_state = FlowState.PREVIEW
+
+    except RMLGenerationError as e:
+        logger.error(f"RML regeneration failed: {e}")
+        state.error_message = f"Failed to regenerate RML: {e}"
+        state.current_state = FlowState.ERROR
+
+    return state
+
+
 def validate_node(
     state: GraphState,
     rmlmapper_jar: str | None = None,

--- a/src/ogd_to_lod/graph/state.py
+++ b/src/ogd_to_lod/graph/state.py
@@ -115,6 +115,7 @@ class GraphState:
     generated_rml: str | None = None
     rdf_preview: str | None = None
     validation_error: str | None = None
+    validation_retry_count: int = 0
 
     # PR info (populated in CREATE_PR state)
     pr_url: str | None = None
@@ -155,6 +156,7 @@ class GraphState:
             "generated_rml": self.generated_rml,
             "rdf_preview": self.rdf_preview,
             "validation_error": self.validation_error,
+            "validation_retry_count": self.validation_retry_count,
             "pr_url": self.pr_url,
             "pr_number": self.pr_number,
             "messages": self.messages,

--- a/src/ogd_to_lod/rml/__init__.py
+++ b/src/ogd_to_lod/rml/__init__.py
@@ -5,11 +5,12 @@ from ogd_to_lod.rml.generator import (
     RMLGenerator,
     generate_rml,
 )
-from ogd_to_lod.rml.prompts import RML_GENERATION_PROMPT
+from ogd_to_lod.rml.prompts import RML_CORRECTION_PROMPT, RML_GENERATION_PROMPT
 
 __all__ = [
     "RMLGenerator",
     "RMLGenerationError",
     "generate_rml",
+    "RML_CORRECTION_PROMPT",
     "RML_GENERATION_PROMPT",
 ]

--- a/src/ogd_to_lod/rml/generator.py
+++ b/src/ogd_to_lod/rml/generator.py
@@ -1,11 +1,12 @@
 """RML generation using AI service."""
 
+import re
 from pathlib import Path
 from typing import Any
 
 from ogd_to_lod.ai import AIService
 from ogd_to_lod.logging import get_logger
-from ogd_to_lod.rml.prompts import RML_GENERATION_PROMPT
+from ogd_to_lod.rml.prompts import RML_CORRECTION_PROMPT, RML_GENERATION_PROMPT
 
 logger = get_logger(__name__)
 
@@ -84,6 +85,7 @@ class RMLGenerator:
                 )
 
             rml_content = turtle_blocks[0]
+            rml_content = self.ensure_common_prefixes(rml_content)
             logger.info(f"Generated RML with {len(rml_content)} characters")
 
             return rml_content
@@ -93,6 +95,99 @@ class RMLGenerator:
         except Exception as e:
             logger.error(f"Failed to generate RML: {e}")
             raise RMLGenerationError(f"Failed to generate RML: {e}") from e
+
+    def regenerate_with_error(self, error_message: str) -> str:
+        """Re-generate RML by sending the validation error back to the AI.
+
+        The AI's conversation history already contains the previous RML output,
+        so we only need to send the correction prompt with the error.
+
+        Args:
+            error_message: The validation error from Tier 1 syntax check.
+
+        Returns:
+            Corrected RML in Turtle format.
+
+        Raises:
+            RMLGenerationError: If regeneration fails or no valid RML is produced.
+        """
+        logger.info("Regenerating RML with error context")
+
+        prompt = RML_CORRECTION_PROMPT.format(error_message=error_message)
+
+        logger.debug("Sending RML correction prompt to AI")
+
+        try:
+            response = self._ai_service.send_message(prompt)
+            parsed = AIService.parse_response(response)
+
+            turtle_blocks = parsed.get_turtle_blocks()
+
+            if not turtle_blocks:
+                logger.warning("No Turtle code block found in AI correction response")
+                raise RMLGenerationError(
+                    "AI did not return corrected RML Turtle output. "
+                    "Response did not contain a turtle code block."
+                )
+
+            rml_content = turtle_blocks[0]
+            rml_content = self.ensure_common_prefixes(rml_content)
+            logger.info(f"Regenerated RML with {len(rml_content)} characters")
+
+            return rml_content
+
+        except RMLGenerationError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to regenerate RML: {e}")
+            raise RMLGenerationError(f"Failed to regenerate RML: {e}") from e
+
+    @staticmethod
+    def ensure_common_prefixes(turtle_content: str) -> str:
+        """Ensure well-known prefixes are declared if they are used.
+
+        Scans the Turtle content for usage of common prefixed names (e.g.
+        ``rdfs:label``) and prepends any missing ``@prefix`` declarations.
+
+        Args:
+            turtle_content: Raw Turtle content.
+
+        Returns:
+            Turtle content with missing prefix declarations prepended.
+        """
+        # Map of prefix -> IRI for well-known vocabularies
+        well_known = {
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "dcterms": "http://purl.org/dc/terms/",
+            "schema": "http://schema.org/",
+            "foaf": "http://xmlns.com/foaf/0.1/",
+        }
+
+        missing: list[str] = []
+        for prefix, iri in well_known.items():
+            # Check if prefix is used (e.g. "rdfs:" appearing as a prefixed name)
+            usage_pattern = re.compile(rf'(?<![:\w]){re.escape(prefix)}:\w')
+            if not usage_pattern.search(turtle_content):
+                continue
+
+            # Check if it is already declared
+            decl_pattern = re.compile(
+                rf'@prefix\s+{re.escape(prefix)}\s*:', re.IGNORECASE
+            )
+            if decl_pattern.search(turtle_content):
+                continue
+
+            missing.append(f"@prefix {prefix}: <{iri}> .")
+
+        if missing:
+            logger.debug(f"Injecting missing prefixes: {missing}")
+            return "\n".join(missing) + "\n" + turtle_content
+
+        return turtle_content
 
     def _format_proposal(self, proposal: dict[str, Any]) -> str:
         """Format mapping proposal for AI prompt.

--- a/src/ogd_to_lod/rml/generator.py
+++ b/src/ogd_to_lod/rml/generator.py
@@ -1,5 +1,6 @@
 """RML generation using AI service."""
 
+from pathlib import Path
 from typing import Any
 
 from ogd_to_lod.ai import AIService
@@ -57,10 +58,11 @@ class RMLGenerator:
         proposal_text = self._format_proposal(mapping_proposal)
         schema_text = self._format_schema(csv_schema)
 
-        # Build the prompt
+        # Build the prompt — use only the CSV basename so that the generated
+        # rml:source value is a plain filename (validation runs in a temp dir).
         prompt = RML_GENERATION_PROMPT.format(
             base_uri=base_uri,
-            csv_path=csv_path,
+            csv_path=Path(csv_path).name,
             mapping_proposal=proposal_text,
             csv_schema=schema_text,
         )

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -10,6 +10,8 @@ Always use the following standard prefixes:
 - @prefix rr: <http://www.w3.org/ns/r2rml#> .
 - @prefix rml: <http://semweb.mmlab.be/ns/rml#> .
 - @prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+- @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+- @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 - @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 - @prefix schema: <http://schema.org/> .
 - @prefix cube: <https://cube.link/> .
@@ -90,6 +92,18 @@ Do not include explanations outside the code block.
 ```turtle
 # Your RML mapping here
 ```
+"""
+
+RML_CORRECTION_PROMPT = """\
+The RML Turtle you generated has a syntax error. Please fix it.
+
+## Error
+{error_message}
+
+## Instructions
+- Fix ONLY the issue described above.
+- Return the complete corrected RML in a fenced ```turtle``` code block.
+- Do NOT change anything else about the mapping.
 """
 
 RML_VALIDATION_PROMPT = """\

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -21,8 +21,9 @@ For example, if the mapping uses dimensions, measures, and observations:
 - @prefix ex-measure: <{base_uri}measure/> .
 - @prefix ex-obs: <{base_uri}observation/> .
 
-## CRITICAL: Turtle Syntax Rule for Prefixed Names
+## CRITICAL: Turtle Syntax Rules
 
+### No `/` in prefixed name local parts
 The `/` character is NOT allowed in the local part of a prefixed name. \
 This is a hard constraint of the W3C Turtle grammar (PN_LOCAL production).
 
@@ -38,6 +39,11 @@ CORRECT — use sub-prefixes instead:
 
 You MUST define a sub-prefix for every sub-path and use it consistently. \
 Never write a prefixed name that contains `/` in the local part.
+
+### No relative IRIs (e.g. <#Name>)
+Do NOT use relative IRIs such as `<#LogicalSource>` or `<#TriplesMap>`. \
+RMLMapper uses RDF4J which rejects relative IRIs without a @base directive. \
+Instead, use prefixed names like `ex:LogicalSource` or `ex:TriplesMap`.
 
 ## CSV Source Configuration
 The CSV source file path is: {csv_path}

--- a/src/ogd_to_lod/validation/__init__.py
+++ b/src/ogd_to_lod/validation/__init__.py
@@ -1,9 +1,9 @@
 """RML validation using RMLMapper."""
 
 from ogd_to_lod.validation.validator import (
-    RMLValidator,
-    RMLValidationError,
     RMLMapperNotFoundError,
+    RMLValidationError,
+    RMLValidator,
     ValidationResult,
     validate_rml,
 )

--- a/src/ogd_to_lod/validation/validator.py
+++ b/src/ogd_to_lod/validation/validator.py
@@ -1,13 +1,17 @@
 """RML validation using RMLMapper.
 
-This module provides functionality to validate RML mappings by executing them
-against sample CSV data using the RMLMapper tool.
+This module provides two-tier validation for RML mappings:
+- Tier 1 (syntax): Cheap rdflib parse check, suitable for auto-retry on AI errors.
+- Tier 2 (RMLMapper): Thorough data-aware check using sample CSV data, escalates to
+  user on failure since data-fit issues need human judgement.
 """
 
+import csv
 import os
+import re
 import subprocess
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from ogd_to_lod.logging import get_logger
@@ -37,21 +41,24 @@ class ValidationResult:
         rdf_output: Generated RDF output if valid (Turtle format).
         error_message: Error message if invalid.
         warnings: List of warnings from validation.
+        error_category: Categorised error type (e.g. "missing_column", "invalid_iri").
+        user_friendly_error: Human-readable explanation of the error.
     """
 
     valid: bool
     rdf_output: str | None = None
     error_message: str | None = None
     warnings: list[str] | None = None
+    error_category: str | None = None
+    user_friendly_error: str | None = None
 
 
 class RMLValidator:
     """Validates RML mappings using RMLMapper.
 
-    This validator executes RML mappings against CSV data to verify:
-    1. The RML syntax is valid
-    2. The mapping can be executed against the source data
-    3. Valid RDF is produced
+    This validator supports two tiers:
+    1. Syntax validation via rdflib (fast, no external dependencies)
+    2. Full validation via RMLMapper against sample CSV data
 
     The validator uses RMLMapper, a Java-based tool that must be available
     either as a JAR file or via Docker.
@@ -82,6 +89,137 @@ class RMLValidator:
         else:
             self._rmlmapper_jar = rmlmapper_jar or os.environ.get("RMLMAPPER_JAR")
 
+    # ── Tier 1: Syntax validation ────────────────────────────────────────
+
+    def validate_syntax(self, rml_content: str) -> ValidationResult:
+        """Validate RML Turtle syntax using rdflib (Tier 1).
+
+        This is a fast, cheap check that catches syntax errors without needing
+        RMLMapper or CSV data. Suitable for auto-retry when the AI produces
+        invalid Turtle.
+
+        Args:
+            rml_content: RML mapping in Turtle format.
+
+        Returns:
+            ValidationResult with syntax validation outcome.
+        """
+        return self._validate_syntax_only(rml_content)
+
+    # ── Tier 2: RMLMapper validation ─────────────────────────────────────
+
+    def validate_with_rmlmapper(
+        self,
+        rml_content: str,
+        csv_path: str,
+        sample_rows: int = 5,
+        output_format: str = "turtle",
+        timeout: int | None = None,
+    ) -> ValidationResult:
+        """Validate RML by executing it against sample CSV data (Tier 2).
+
+        Extracts the first N rows from the CSV, writes them to a temp directory
+        with the filename the RML expects, then runs RMLMapper.
+
+        Args:
+            rml_content: RML mapping in Turtle format.
+            csv_path: Path to the source CSV file.
+            sample_rows: Number of data rows to include in sample (default: 5).
+            output_format: Output format for RDF (turtle, nquads, jsonld).
+            timeout: Timeout in seconds (default: 60).
+
+        Returns:
+            ValidationResult with validation outcome, including error
+            categorisation on failure.
+        """
+        timeout = timeout or self.DEFAULT_TIMEOUT
+
+        # Check if RMLMapper is available
+        if not self._use_docker and not self._rmlmapper_jar:
+            logger.warning("RMLMapper not configured, skipping Tier 2 validation")
+            return ValidationResult(
+                valid=True,
+                warnings=["RMLMapper not configured — Tier 2 validation skipped"],
+            )
+
+        if not self._use_docker and not Path(self._rmlmapper_jar).exists():
+            logger.warning(
+                f"RMLMapper JAR not found at {self._rmlmapper_jar}, "
+                "skipping Tier 2 validation"
+            )
+            return ValidationResult(
+                valid=True,
+                warnings=[
+                    f"RMLMapper JAR not found at {self._rmlmapper_jar} "
+                    "— Tier 2 validation skipped. "
+                    "Run scripts/setup-rmlmapper.sh to download it."
+                ],
+            )
+
+        # Verify CSV file exists
+        if not Path(csv_path).exists():
+            return ValidationResult(
+                valid=False,
+                error_message=f"CSV file not found: {csv_path}",
+                error_category="file_not_found",
+                user_friendly_error=f"The CSV file '{csv_path}' does not exist.",
+            )
+
+        # Extract sample CSV and run RMLMapper in temp directory
+        tmpdir = self._extract_sample_csv(rml_content, csv_path, sample_rows)
+        try:
+            source_filename = self._get_rml_source_filename(rml_content, csv_path)
+            rml_file = Path(tmpdir.name) / "mapping.ttl"
+            output_file = Path(tmpdir.name) / "output.ttl"
+
+            rml_file.write_text(rml_content)
+
+            try:
+                if self._use_docker:
+                    result = self._run_docker(
+                        rml_file, tmpdir.name, output_file, output_format, timeout
+                    )
+                else:
+                    result = self._run_jar_in_dir(
+                        rml_file, tmpdir.name, output_file, output_format, timeout
+                    )
+
+                # Categorise errors if validation failed
+                if not result.valid and result.error_message:
+                    category, friendly = self._categorize_error(result.error_message)
+                    result.error_category = category
+                    result.user_friendly_error = friendly
+
+                return result
+
+            except subprocess.TimeoutExpired:
+                return ValidationResult(
+                    valid=False,
+                    error_message=f"RMLMapper timed out after {timeout} seconds",
+                    error_category="timeout",
+                    user_friendly_error=(
+                        f"RMLMapper took longer than {timeout} seconds. "
+                        "The mapping may be too complex or contain infinite loops."
+                    ),
+                )
+            except FileNotFoundError as e:
+                raise RMLMapperNotFoundError(
+                    f"RMLMapper not found: {e}. "
+                    "Ensure Java is installed and RMLMAPPER_JAR is set."
+                ) from e
+            except Exception as e:
+                logger.error(f"Unexpected error during validation: {e}")
+                return ValidationResult(
+                    valid=False,
+                    error_message=f"Validation error: {e}",
+                    error_category="unknown",
+                    user_friendly_error=f"An unexpected error occurred: {e}",
+                )
+        finally:
+            tmpdir.cleanup()
+
+    # ── Backward-compatible wrapper ──────────────────────────────────────
+
     def validate(
         self,
         rml_content: str,
@@ -89,7 +227,9 @@ class RMLValidator:
         output_format: str = "turtle",
         timeout: int | None = None,
     ) -> ValidationResult:
-        """Validate an RML mapping by executing it.
+        """Validate an RML mapping by executing it (backward-compatible).
+
+        Runs both tiers: syntax first, then RMLMapper if available.
 
         Args:
             rml_content: RML mapping in Turtle format.
@@ -104,61 +244,161 @@ class RMLValidator:
             RMLMapperNotFoundError: If RMLMapper is not available.
             RMLValidationError: If validation fails due to configuration issues.
         """
-        timeout = timeout or self.DEFAULT_TIMEOUT
+        # Tier 1: syntax check
+        syntax_result = self.validate_syntax(rml_content)
+        if not syntax_result.valid:
+            return syntax_result
 
-        # Check if RMLMapper is available
-        if not self._use_docker and not self._rmlmapper_jar:
-            logger.warning("RMLMapper JAR not configured, using syntax-only validation")
-            return self._validate_syntax_only(rml_content)
+        # Tier 2: RMLMapper check
+        return self.validate_with_rmlmapper(
+            rml_content, csv_path, output_format=output_format, timeout=timeout
+        )
 
-        # Verify CSV file exists
-        if not Path(csv_path).exists():
-            return ValidationResult(
-                valid=False,
-                error_message=f"CSV file not found: {csv_path}",
-            )
+    # ── Sample CSV extraction ────────────────────────────────────────────
 
-        # Create temporary files for RML and output
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rml_file = Path(tmpdir) / "mapping.ttl"
-            output_file = Path(tmpdir) / "output.ttl"
+    def _extract_sample_csv(
+        self,
+        rml_content: str,
+        csv_path: str,
+        sample_rows: int = 5,
+    ) -> tempfile.TemporaryDirectory:
+        """Extract header + first N rows from a CSV for validation.
 
-            # Write RML to temp file
-            rml_file.write_text(rml_content)
+        The sample file is written into a temp directory using the filename
+        that the RML mapping expects (parsed from rml:source).
+
+        Args:
+            rml_content: RML content to parse source filename from.
+            csv_path: Path to the full CSV file.
+            sample_rows: Number of data rows to include.
+
+        Returns:
+            TemporaryDirectory containing the sample CSV. Caller must manage
+            its lifecycle (cleanup).
+        """
+        source_filename = self._get_rml_source_filename(rml_content, csv_path)
+        tmpdir = tempfile.TemporaryDirectory()
+
+        try:
+            source_path = Path(csv_path)
+            dest_path = Path(tmpdir.name) / source_filename
+
+            # Detect delimiter by reading the first line
+            with open(source_path, "r", newline="", encoding="utf-8") as f:
+                sample = f.read(8192)
 
             try:
-                if self._use_docker:
-                    result = self._run_docker(
-                        rml_file, csv_path, output_file, output_format, timeout
-                    )
-                else:
-                    result = self._run_jar(
-                        rml_file, csv_path, output_file, output_format, timeout
-                    )
+                dialect = csv.Sniffer().sniff(sample)
+                delimiter = dialect.delimiter
+            except csv.Error:
+                delimiter = ","
 
-                return result
+            # Read header + first N rows
+            with open(source_path, "r", newline="", encoding="utf-8") as src:
+                reader = csv.reader(src, delimiter=delimiter)
+                rows = []
+                for i, row in enumerate(reader):
+                    rows.append(row)
+                    if i >= sample_rows:  # header + sample_rows data rows
+                        break
 
-            except subprocess.TimeoutExpired:
-                return ValidationResult(
-                    valid=False,
-                    error_message=f"RMLMapper timed out after {timeout} seconds",
-                )
-            except FileNotFoundError as e:
-                raise RMLMapperNotFoundError(
-                    f"RMLMapper not found: {e}. "
-                    "Ensure Java is installed and RMLMAPPER_JAR is set."
-                ) from e
-            except Exception as e:
-                logger.error(f"Unexpected error during validation: {e}")
-                return ValidationResult(
-                    valid=False,
-                    error_message=f"Validation error: {e}",
-                )
+            # Write sample CSV
+            with open(dest_path, "w", newline="", encoding="utf-8") as dst:
+                writer = csv.writer(dst, delimiter=delimiter)
+                writer.writerows(rows)
+
+            logger.debug(
+                f"Extracted sample CSV: {len(rows)} rows "
+                f"(incl. header) → {dest_path}"
+            )
+
+        except Exception:
+            tmpdir.cleanup()
+            raise
+
+        return tmpdir
+
+    @staticmethod
+    def _get_rml_source_filename(rml_content: str, csv_path: str) -> str:
+        """Parse the source filename from RML content.
+
+        Looks for rml:source "filename" pattern. Falls back to the basename
+        of the provided csv_path.
+
+        Args:
+            rml_content: RML content in Turtle format.
+            csv_path: Fallback CSV path.
+
+        Returns:
+            The filename the RML expects.
+        """
+        match = re.search(r'rml:source\s+"([^"]+)"', rml_content)
+        if match:
+            return match.group(1)
+        return Path(csv_path).name
+
+    # ── Error categorisation ─────────────────────────────────────────────
+
+    @staticmethod
+    def _categorize_error(error_message: str) -> tuple[str, str]:
+        """Categorise an RMLMapper error into a user-friendly bucket.
+
+        Args:
+            error_message: Raw error message from RMLMapper.
+
+        Returns:
+            Tuple of (category, user_friendly_description).
+        """
+        msg_lower = error_message.lower()
+
+        if "column" in msg_lower and ("not found" in msg_lower or "missing" in msg_lower):
+            return (
+                "missing_column",
+                "The mapping references a CSV column that does not exist. "
+                "Check that column names match the CSV header exactly "
+                "(including case and whitespace).",
+            )
+
+        if "iri" in msg_lower or "uri" in msg_lower or "invalid url" in msg_lower:
+            return (
+                "invalid_iri",
+                "The mapping generates an invalid IRI/URI. "
+                "This usually means a template contains characters that "
+                "are not allowed in URIs (spaces, special characters).",
+            )
+
+        if "type" in msg_lower and ("mismatch" in msg_lower or "cast" in msg_lower):
+            return (
+                "type_mismatch",
+                "A data value cannot be converted to the expected type "
+                "(e.g. text where a number is expected). Check the datatype "
+                "annotations in the mapping.",
+            )
+
+        if "file" in msg_lower and "not found" in msg_lower:
+            return (
+                "file_not_found",
+                "The mapping references a file that could not be found. "
+                "Ensure the rml:source filename matches the actual CSV file.",
+            )
+
+        if "parse" in msg_lower or "syntax" in msg_lower:
+            return (
+                "syntax_error",
+                "The RML mapping has a syntax error that RMLMapper could "
+                "not parse. This may be a Turtle formatting issue.",
+            )
+
+        return (
+            "unknown",
+            f"RMLMapper validation failed: {error_message[:200]}",
+        )
+
+    # ── Internal helpers ─────────────────────────────────────────────────
 
     def _validate_syntax_only(self, rml_content: str) -> ValidationResult:
         """Validate RML syntax without executing the mapping.
 
-        This is a fallback when RMLMapper is not available.
         Uses rdflib to parse the Turtle syntax.
 
         Args:
@@ -214,6 +454,50 @@ class RMLValidator:
                 error_message=f"RML syntax error: {e}",
             )
 
+    def _run_jar_in_dir(
+        self,
+        rml_file: Path,
+        working_dir: str,
+        output_file: Path,
+        output_format: str,
+        timeout: int,
+    ) -> ValidationResult:
+        """Execute RMLMapper JAR file with a specific working directory.
+
+        Args:
+            rml_file: Path to RML mapping file.
+            working_dir: Directory containing the sample CSV.
+            output_file: Path for output file.
+            output_format: Output format.
+            timeout: Timeout in seconds.
+
+        Returns:
+            ValidationResult with execution outcome.
+        """
+        cmd = [
+            "java",
+            "-jar",
+            self._rmlmapper_jar,
+            "-m",
+            str(rml_file),
+            "-o",
+            str(output_file),
+            "-s",
+            output_format,
+        ]
+
+        logger.debug(f"Running RMLMapper: {' '.join(cmd)}")
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=working_dir,
+        )
+
+        return self._process_result(result, output_file)
+
     def _run_jar(
         self,
         rml_file: Path,
@@ -234,7 +518,6 @@ class RMLValidator:
         Returns:
             ValidationResult with execution outcome.
         """
-        # Build command
         cmd = [
             "java",
             "-jar",
@@ -249,13 +532,12 @@ class RMLValidator:
 
         logger.debug(f"Running RMLMapper: {' '.join(cmd)}")
 
-        # Execute RMLMapper
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout,
-            cwd=Path(csv_path).parent,  # Run in CSV directory
+            cwd=Path(csv_path).parent,
         )
 
         return self._process_result(result, output_file)
@@ -272,7 +554,7 @@ class RMLValidator:
 
         Args:
             rml_file: Path to RML mapping file.
-            csv_path: Path to CSV source file.
+            csv_path: Path to CSV source file or directory containing CSV.
             output_file: Path for output file.
             output_format: Output format.
             timeout: Timeout in seconds.
@@ -280,10 +562,8 @@ class RMLValidator:
         Returns:
             ValidationResult with execution outcome.
         """
-        csv_dir = Path(csv_path).parent
-        csv_filename = Path(csv_path).name
+        csv_dir = Path(csv_path) if Path(csv_path).is_dir() else Path(csv_path).parent
 
-        # Build Docker command
         cmd = [
             "docker",
             "run",
@@ -303,7 +583,6 @@ class RMLValidator:
 
         logger.debug(f"Running RMLMapper via Docker: {' '.join(cmd)}")
 
-        # Execute Docker
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -325,10 +604,8 @@ class RMLValidator:
         Returns:
             ValidationResult based on execution outcome.
         """
-        # Check for errors
         if result.returncode != 0:
             error_msg = result.stderr or result.stdout or "Unknown error"
-            # Clean up common RMLMapper error messages
             error_msg = self._clean_error_message(error_msg)
 
             logger.debug(f"RMLMapper failed: {error_msg}")
@@ -338,12 +615,10 @@ class RMLValidator:
                 error_message=error_msg,
             )
 
-        # Read output
         try:
             if output_file.exists():
                 rdf_output = output_file.read_text()
 
-                # Parse warnings from stderr
                 warnings = None
                 if result.stderr:
                     warning_lines = [
@@ -380,18 +655,15 @@ class RMLValidator:
         Returns:
             Cleaned error message.
         """
-        # Remove Java stack traces for cleaner messages
         lines = error_msg.splitlines()
         cleaned_lines = []
 
         for line in lines:
-            # Skip stack trace lines
             if line.strip().startswith("at "):
                 continue
             if line.strip().startswith("Caused by:"):
                 continue
             if "java." in line and "Exception" in line:
-                # Keep the exception message but simplify
                 if ":" in line:
                     cleaned_lines.append(line.split(":")[-1].strip())
                 continue

--- a/src/ogd_to_lod/validation/validator.py
+++ b/src/ogd_to_lod/validation/validator.py
@@ -87,7 +87,10 @@ class RMLValidator:
         if use_docker:
             self._rmlmapper_jar = None
         else:
-            self._rmlmapper_jar = rmlmapper_jar or os.environ.get("RMLMAPPER_JAR")
+            jar = rmlmapper_jar or os.environ.get("RMLMAPPER_JAR")
+            # Resolve to absolute so the path works even when cwd changes
+            # (e.g. when running RMLMapper in a temp directory).
+            self._rmlmapper_jar = str(Path(jar).resolve()) if jar else None
 
     # ── Tier 1: Syntax validation ────────────────────────────────────────
 
@@ -172,7 +175,7 @@ class RMLValidator:
             rml_file = Path(tmpdir.name) / "mapping.ttl"
             output_file = Path(tmpdir.name) / "output.ttl"
 
-            rml_file.write_text(rml_content)
+            rml_file.write_text(self._ensure_base_directive(rml_content))
 
             try:
                 if self._use_docker:
@@ -302,7 +305,8 @@ class RMLValidator:
                     if i >= sample_rows:  # header + sample_rows data rows
                         break
 
-            # Write sample CSV
+            # Write sample CSV (create intermediate dirs for paths like "data/file.csv")
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
             with open(dest_path, "w", newline="", encoding="utf-8") as dst:
                 writer = csv.writer(dst, delimiter=delimiter)
                 writer.writerows(rows)
@@ -317,6 +321,26 @@ class RMLValidator:
             raise
 
         return tmpdir
+
+    @staticmethod
+    def _ensure_base_directive(rml_content: str) -> str:
+        """Prepend a @base directive if the RML uses relative IRIs without one.
+
+        RMLMapper (RDF4J) rejects relative IRIs like <#LogicalSource> when no
+        @base is declared.  Adding a dummy base lets them resolve correctly.
+
+        Args:
+            rml_content: RML content in Turtle format.
+
+        Returns:
+            RML content with @base prepended if needed.
+        """
+        has_base = bool(re.search(r'@base\s+<', rml_content, re.IGNORECASE))
+        has_relative_iris = bool(re.search(r'<#\w', rml_content))
+        if has_relative_iris and not has_base:
+            logger.debug("Injecting @base directive for relative IRIs")
+            return '@base <http://example.org/mapping/> .\n' + rml_content
+        return rml_content
 
     @staticmethod
     def _get_rml_source_filename(rml_content: str, csv_path: str) -> str:

--- a/src/ogd_to_lod/validation/validator.py
+++ b/src/ogd_to_lod/validation/validator.py
@@ -418,6 +418,34 @@ class RMLValidator:
             f"RMLMapper validation failed: {error_message[:200]}",
         )
 
+    # ── Output analysis ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_empty_rdf_output(rdf_output: str) -> bool:
+        """Check whether RDF output contains only prefix/base declarations.
+
+        RMLMapper exits successfully even when no triples are generated
+        (e.g. when CSV column references don't match due to a wrong
+        delimiter).  The output file will contain @prefix declarations
+        but no actual data triples.
+
+        Args:
+            rdf_output: RDF output string (Turtle format).
+
+        Returns:
+            True if the output has no data triples.
+        """
+        for line in rdf_output.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("#", "@prefix", "@base")):
+                continue
+            # PREFIX / BASE (SPARQL-style declarations)
+            upper = stripped.upper()
+            if upper.startswith("PREFIX ") or upper.startswith("BASE "):
+                continue
+            return False  # Found actual content
+        return True
+
     # ── Internal helpers ─────────────────────────────────────────────────
 
     def _validate_syntax_only(self, rml_content: str) -> ValidationResult:
@@ -642,6 +670,24 @@ class RMLValidator:
         try:
             if output_file.exists():
                 rdf_output = output_file.read_text()
+
+                # Check for empty output (only prefixes, no data triples)
+                if self._is_empty_rdf_output(rdf_output):
+                    return ValidationResult(
+                        valid=False,
+                        error_message=(
+                            "RMLMapper produced no output triples "
+                            "— only prefix declarations."
+                        ),
+                        error_category="empty_output",
+                        user_friendly_error=(
+                            "The mapping executed successfully but produced "
+                            "no RDF triples. This usually means the column "
+                            "references in the mapping don't match the CSV "
+                            "headers (check delimiter, column names, and "
+                            "letter case)."
+                        ),
+                    )
 
                 warnings = None
                 if result.stderr:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest fixtures for the ogd-to-lod test suite."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+# ── Paths to persistent fixture files ───────────────────────────────────
+
+@pytest.fixture(scope="session")
+def data_dir():
+    """Root directory containing persistent test fixtures."""
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def data_csv(data_dir):
+    """Path (str) to the 7-row comma-delimited CSV fixture."""
+    return str(data_dir / "data.csv")
+
+
+@pytest.fixture(scope="session")
+def semicolon_csv(data_dir):
+    """Path (str) to the 3-row semicolon-delimited CSV fixture."""
+    return str(data_dir / "semicolon.csv")
+
+
+@pytest.fixture(scope="session")
+def small_csv(data_dir):
+    """Path (str) to the 1-row comma-delimited CSV fixture."""
+    return str(data_dir / "small.csv")
+
+
+@pytest.fixture(scope="session")
+def sample_rml(data_dir):
+    """The SAMPLE_RML Turtle content used across validation tests."""
+    return (data_dir / "sample.rml.ttl").read_text()
+
+
+# ── RMLMapper availability fixtures (for integration tests) ────────────
+
+@pytest.fixture(scope="session")
+def rmlmapper_jar():
+    """Path to the RMLMapper JAR, or skip if not present."""
+    jar_path = Path(__file__).parent.parent / "tools" / "rmlmapper.jar"
+    if not jar_path.exists():
+        pytest.skip("RMLMapper JAR not found at tools/rmlmapper.jar")
+    return str(jar_path)
+
+
+@pytest.fixture(scope="session")
+def java_available():
+    """Assert that java is on PATH, or skip."""
+    if shutil.which("java") is None:
+        pytest.skip("Java runtime not found on PATH")
+
+
+@pytest.fixture(scope="session")
+def rmlmapper_available(rmlmapper_jar, java_available):
+    """Ensure both JAR and Java are present; return the JAR path."""
+    return rmlmapper_jar

--- a/tests/data/data.csv
+++ b/tests/data/data.csv
@@ -1,0 +1,8 @@
+year,region,value
+2020,North,100.5
+2021,South,200.3
+2022,East,300.1
+2023,West,400.7
+2024,North,500.2
+2025,South,600.9
+2026,East,700.4

--- a/tests/data/sample.rml.ttl
+++ b/tests/data/sample.rml.ttl
@@ -1,0 +1,38 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema: <http://schema.org/> .
+@prefix cube: <https://cube.link/> .
+@prefix ex: <https://example.org/> .
+
+ex:TriplesMap a rr:TriplesMap ;
+    rml:logicalSource [
+        rml:source "data.csv" ;
+        rml:referenceFormulation ql:CSV
+    ] ;
+    rr:subjectMap [
+        rr:template "https://example.org/observation/{year}/{region}" ;
+        rr:class cube:Observation
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:dimension ;
+        rr:objectMap [
+            rml:reference "year" ;
+            rr:datatype xsd:gYear
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:dimension ;
+        rr:objectMap [
+            rml:reference "region" ;
+            rr:datatype xsd:string
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate cube:measure ;
+        rr:objectMap [
+            rml:reference "value" ;
+            rr:datatype xsd:decimal
+        ]
+    ] .

--- a/tests/data/semicolon.csv
+++ b/tests/data/semicolon.csv
@@ -1,0 +1,4 @@
+year;region;value
+2020;North;100.5
+2021;South;200.3
+2022;East;300.1

--- a/tests/data/small.csv
+++ b/tests/data/small.csv
@@ -1,0 +1,2 @@
+year,region,value
+2020,North,100.5

--- a/tests/test_rml.py
+++ b/tests/test_rml.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from ogd_to_lod.config import Config, GitHubConfig, AzureOpenAIConfig, RMLConfig
 from ogd_to_lod.rml import RMLGenerator, RMLGenerationError, generate_rml
-from ogd_to_lod.rml.prompts import RML_GENERATION_PROMPT
+from ogd_to_lod.rml.prompts import RML_CORRECTION_PROMPT, RML_GENERATION_PROMPT
 from ogd_to_lod.graph.state import (
     DimensionProposal,
     FlowState,
@@ -13,7 +13,7 @@ from ogd_to_lod.graph.state import (
     MappingProposal,
     MeasureProposal,
 )
-from ogd_to_lod.graph.nodes import generate_node
+from ogd_to_lod.graph.nodes import generate_node, regenerate_node
 
 
 # Sample RML output for testing
@@ -308,6 +308,8 @@ class TestRMLPrompts:
         assert "cube:" in RML_GENERATION_PROMPT
         assert "schema:" in RML_GENERATION_PROMPT
         assert "xsd:" in RML_GENERATION_PROMPT
+        assert "rdf:" in RML_GENERATION_PROMPT
+        assert "rdfs:" in RML_GENERATION_PROMPT
 
     def test_prompt_has_placeholders(self):
         """Test that the prompt has required placeholders."""
@@ -328,3 +330,163 @@ class TestRMLPrompts:
         assert "schema.org" in RML_GENERATION_PROMPT
         assert "DefinedTerm" in RML_GENERATION_PROMPT
         assert "DefinedTermSet" in RML_GENERATION_PROMPT
+
+
+class TestRMLCorrectionPrompt:
+    """Tests for the RML_CORRECTION_PROMPT template."""
+
+    def test_has_error_message_placeholder(self):
+        """Test that the correction prompt contains the error_message placeholder."""
+        assert "{error_message}" in RML_CORRECTION_PROMPT
+
+    def test_mentions_turtle_code_block(self):
+        """Test that the correction prompt asks for a turtle code block."""
+        assert "turtle" in RML_CORRECTION_PROMPT
+
+    def test_format_with_error(self):
+        """Test that the correction prompt can be formatted with an error message."""
+        formatted = RML_CORRECTION_PROMPT.format(
+            error_message='Prefix "rdfs:" not bound'
+        )
+        assert 'Prefix "rdfs:" not bound' in formatted
+        assert "Fix ONLY" in formatted
+
+
+class TestRMLGeneratorRegenerate:
+    """Tests for RMLGenerator.regenerate_with_error()."""
+
+    def test_regenerate_sends_error_context(self, mock_ai_service):
+        """Test that regenerate_with_error sends the error message to the AI."""
+        generator = RMLGenerator(mock_ai_service)
+
+        result = generator.regenerate_with_error('Prefix "rdfs:" not bound')
+
+        assert result is not None
+        # Verify the correction prompt was sent with the error
+        call_args = mock_ai_service.send_message.call_args[0][0]
+        assert 'Prefix "rdfs:" not bound' in call_args
+
+    def test_regenerate_no_turtle_block(self, mock_ai_service):
+        """Test that regenerate_with_error raises when no turtle block returned."""
+        mock_ai_service.send_message.return_value = "I cannot fix this error."
+
+        generator = RMLGenerator(mock_ai_service)
+
+        with pytest.raises(RMLGenerationError) as exc_info:
+            generator.regenerate_with_error("some error")
+
+        assert "did not return corrected RML" in str(exc_info.value)
+
+    def test_regenerate_ai_error(self, mock_ai_service):
+        """Test that regenerate_with_error wraps AI exceptions."""
+        mock_ai_service.send_message.side_effect = Exception("API error")
+
+        generator = RMLGenerator(mock_ai_service)
+
+        with pytest.raises(RMLGenerationError) as exc_info:
+            generator.regenerate_with_error("some error")
+
+        assert "Failed to regenerate RML" in str(exc_info.value)
+
+
+class TestEnsureCommonPrefixes:
+    """Tests for RMLGenerator.ensure_common_prefixes()."""
+
+    def test_injects_missing_rdfs(self):
+        """Test that missing rdfs: prefix is injected when used."""
+        turtle = (
+            '@prefix rr: <http://www.w3.org/ns/r2rml#> .\n'
+            'ex:Thing rdfs:label "hello" .\n'
+        )
+        result = RMLGenerator.ensure_common_prefixes(turtle)
+        assert "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ." in result
+        # Original content preserved
+        assert 'rdfs:label "hello"' in result
+
+    def test_no_duplication_of_existing_prefix(self):
+        """Test that an already-declared prefix is not duplicated."""
+        turtle = (
+            '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n'
+            'ex:Thing rdfs:label "hello" .\n'
+        )
+        result = RMLGenerator.ensure_common_prefixes(turtle)
+        assert result.count("@prefix rdfs:") == 1
+
+    def test_no_injection_when_prefix_unused(self):
+        """Test that a prefix is not injected when it is not used."""
+        turtle = (
+            '@prefix rr: <http://www.w3.org/ns/r2rml#> .\n'
+            'ex:Thing rr:class "Foo" .\n'
+        )
+        result = RMLGenerator.ensure_common_prefixes(turtle)
+        assert "@prefix rdfs:" not in result
+        assert "@prefix owl:" not in result
+
+    def test_multiple_missing_prefixes(self):
+        """Test that multiple missing prefixes are all injected."""
+        turtle = (
+            'ex:Thing rdfs:label "hello" ;\n'
+            '    rdf:type owl:Class .\n'
+        )
+        result = RMLGenerator.ensure_common_prefixes(turtle)
+        assert "@prefix rdf:" in result
+        assert "@prefix rdfs:" in result
+        assert "@prefix owl:" in result
+
+    def test_returns_unchanged_when_nothing_missing(self):
+        """Test that content is returned unchanged when no prefixes are missing."""
+        turtle = '@prefix rr: <http://www.w3.org/ns/r2rml#> .\nex:Thing rr:class "Foo" .\n'
+        result = RMLGenerator.ensure_common_prefixes(turtle)
+        assert result == turtle
+
+
+class TestRegenerateNode:
+    """Tests for the regenerate_node graph node function."""
+
+    def test_regenerate_node_success(self, mock_ai_service):
+        """Test successful regeneration via node."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path="/path/to/data.csv",
+            base_uri="https://example.org/",
+            validation_error='Prefix "rdfs:" not bound',
+            generated_rml="invalid content",
+        )
+
+        result = regenerate_node(state, mock_ai_service)
+
+        assert result.generated_rml is not None
+        assert "@prefix rr:" in result.generated_rml
+        assert result.current_state == FlowState.PREVIEW
+
+    def test_regenerate_node_uses_validation_error(self, mock_ai_service):
+        """Test that regenerate_node passes validation_error to AI."""
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path="/path/to/data.csv",
+            base_uri="https://example.org/",
+            validation_error='Prefix "rdfs:" not bound',
+            generated_rml="invalid content",
+        )
+
+        regenerate_node(state, mock_ai_service)
+
+        call_args = mock_ai_service.send_message.call_args[0][0]
+        assert 'Prefix "rdfs:" not bound' in call_args
+
+    def test_regenerate_node_ai_failure(self, mock_ai_service):
+        """Test regenerate_node handles AI failure."""
+        mock_ai_service.send_message.return_value = "No code block here."
+
+        state = GraphState(
+            current_state=FlowState.GENERATE,
+            csv_path="/path/to/data.csv",
+            base_uri="https://example.org/",
+            validation_error="some error",
+            generated_rml="invalid content",
+        )
+
+        result = regenerate_node(state, mock_ai_service)
+
+        assert result.current_state == FlowState.ERROR
+        assert "Failed to regenerate RML" in result.error_message

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,22 +1,21 @@
 """Tests for RML validation module."""
 
+import csv
 import os
 import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from ogd_to_lod.validation import (
-    RMLValidator,
-    RMLValidationError,
     RMLMapperNotFoundError,
+    RMLValidationError,
+    RMLValidator,
     ValidationResult,
     validate_rml,
 )
-from ogd_to_lod.graph.state import FlowState, GraphState, MappingProposal
-from ogd_to_lod.graph.nodes import validate_node
 
 
 # Sample RML for testing
@@ -83,8 +82,31 @@ def temp_csv():
         f.write("year,region,value\n")
         f.write("2020,North,100.5\n")
         f.write("2021,South,200.3\n")
-        yield f.name
-    os.unlink(f.name)
+        f.write("2022,East,300.1\n")
+        f.write("2023,West,400.7\n")
+        f.write("2024,North,500.2\n")
+        f.write("2025,South,600.9\n")
+        f.write("2026,East,700.4\n")
+        csv_path = f.name
+    # File is now closed and flushed
+    yield csv_path
+    os.unlink(csv_path)
+
+
+@pytest.fixture
+def temp_csv_semicolon():
+    """Create a temporary semicolon-delimited CSV file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False
+    ) as f:
+        f.write("year;region;value\n")
+        f.write("2020;North;100.5\n")
+        f.write("2021;South;200.3\n")
+        f.write("2022;East;300.1\n")
+        csv_path = f.name
+    # File is now closed and flushed
+    yield csv_path
+    os.unlink(csv_path)
 
 
 class TestRMLValidator:
@@ -132,24 +154,32 @@ class TestRMLValidator:
     def test_validate_syntax_only_with_warnings(self):
         """Test syntax-only validation produces warnings for missing components."""
         validator = RMLValidator()
-        result = validator.validate(MINIMAL_RML, "/nonexistent/path.csv")
+        result = validator.validate_syntax(MINIMAL_RML)
 
         # Should be valid syntax but may have warnings
         assert result.valid is True
         # Warnings about missing logical source or subject map
-        if result.warnings:
-            assert any(
-                "logical source" in w.lower() or "subject map" in w.lower()
-                for w in result.warnings
+        assert result.warnings is not None
+        assert any(
+            "logical source" in w.lower() or "subject map" in w.lower()
+            for w in result.warnings
+        )
+
+    def test_validate_csv_not_found(self):
+        """Test validation fails when CSV doesn't exist."""
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            result = validator.validate_with_rmlmapper(
+                SAMPLE_RML, "/nonexistent/data.csv"
             )
 
-    def test_validate_csv_not_found(self, temp_csv):
-        """Test validation fails when CSV doesn't exist."""
-        validator = RMLValidator(rmlmapper_jar="/fake/path.jar")
-        result = validator.validate(SAMPLE_RML, "/nonexistent/data.csv")
-
-        assert result.valid is False
-        assert "not found" in result.error_message.lower()
+            assert result.valid is False
+            assert "not found" in result.error_message.lower()
+        finally:
+            os.unlink(jar_path)
 
     @patch("subprocess.run")
     def test_validate_with_jar_success(self, mock_run, temp_csv):
@@ -272,6 +302,8 @@ class TestValidationResult:
         assert result.rdf_output == "<rdf content>"
         assert result.error_message is None
         assert result.warnings is None
+        assert result.error_category is None
+        assert result.user_friendly_error is None
 
     def test_invalid_result(self):
         """Test invalid result creation."""
@@ -292,6 +324,17 @@ class TestValidationResult:
         assert result.valid is True
         assert len(result.warnings) == 2
 
+    def test_result_with_error_category(self):
+        """Test result with error categorisation fields."""
+        result = ValidationResult(
+            valid=False,
+            error_message="Column 'foo' not found",
+            error_category="missing_column",
+            user_friendly_error="The mapping references a CSV column that does not exist.",
+        )
+        assert result.error_category == "missing_column"
+        assert "does not exist" in result.user_friendly_error
+
 
 class TestValidateRMLFunction:
     """Tests for the validate_rml convenience function."""
@@ -303,92 +346,293 @@ class TestValidateRMLFunction:
         assert result.valid is True
 
 
-class TestValidateNode:
-    """Tests for the validate_node graph function."""
+class TestValidateSyntax:
+    """Tests for the public validate_syntax() method (Tier 1)."""
 
-    def test_validate_node_no_rml(self):
-        """Test validate_node fails without generated RML."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            csv_path="/path/to/data.csv",
+    def test_valid_turtle(self):
+        """Test syntax validation passes for valid Turtle."""
+        validator = RMLValidator()
+        result = validator.validate_syntax(SAMPLE_RML)
+
+        assert result.valid is True
+        assert result.error_message is None
+
+    def test_invalid_turtle(self):
+        """Test syntax validation fails for invalid Turtle."""
+        validator = RMLValidator()
+        result = validator.validate_syntax(INVALID_RML_SYNTAX)
+
+        assert result.valid is False
+        assert result.error_message is not None
+        assert "syntax error" in result.error_message.lower()
+
+    def test_minimal_valid_turtle(self):
+        """Test syntax validation passes for minimal valid Turtle."""
+        validator = RMLValidator()
+        result = validator.validate_syntax(MINIMAL_RML)
+
+        assert result.valid is True
+
+    def test_empty_string(self):
+        """Test syntax validation with empty string."""
+        validator = RMLValidator()
+        result = validator.validate_syntax("")
+
+        # Empty RML is technically parseable Turtle but fails structural
+        # checks (SPARQL queries reference undefined prefixes), so it's
+        # correctly reported as invalid.
+        assert result.valid is False
+
+
+class TestValidateWithRMLMapper:
+    """Tests for validate_with_rmlmapper() method (Tier 2)."""
+
+    def test_skips_when_no_jar_configured(self):
+        """Test Tier 2 gracefully skips when RMLMapper is not configured."""
+        validator = RMLValidator()  # No JAR
+        result = validator.validate_with_rmlmapper(SAMPLE_RML, "/some/path.csv")
+
+        assert result.valid is True
+        assert result.warnings is not None
+        assert any("skipped" in w.lower() for w in result.warnings)
+
+    def test_skips_when_jar_not_found(self):
+        """Test Tier 2 gracefully skips when JAR file doesn't exist."""
+        validator = RMLValidator(rmlmapper_jar="/nonexistent/rmlmapper.jar")
+        result = validator.validate_with_rmlmapper(SAMPLE_RML, "/some/path.csv")
+
+        assert result.valid is True
+        assert result.warnings is not None
+        assert any("not found" in w.lower() for w in result.warnings)
+
+    def test_csv_not_found(self):
+        """Test Tier 2 fails when CSV file doesn't exist."""
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
+
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            result = validator.validate_with_rmlmapper(
+                SAMPLE_RML, "/nonexistent/data.csv"
+            )
+
+            assert result.valid is False
+            assert result.error_category == "file_not_found"
+        finally:
+            os.unlink(jar_path)
+
+    @patch("subprocess.run")
+    def test_success_with_mocked_rmlmapper(self, mock_run, temp_csv):
+        """Test successful Tier 2 validation with mocked RMLMapper."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="",
         )
 
-        result = validate_node(state)
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
 
-        assert result.current_state == FlowState.ERROR
-        assert "No RML to validate" in result.error_message
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            with patch.object(Path, "read_text", return_value="<rdf>"):
+                with patch.object(Path, "exists", return_value=True):
+                    result = validator.validate_with_rmlmapper(
+                        SAMPLE_RML, temp_csv
+                    )
 
-    def test_validate_node_no_csv_path(self):
-        """Test validate_node fails without CSV path."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            generated_rml=SAMPLE_RML,
+            assert result.valid is True
+            assert mock_run.called
+        finally:
+            os.unlink(jar_path)
+
+    @patch("subprocess.run")
+    def test_failure_with_mocked_rmlmapper(self, mock_run, temp_csv):
+        """Test failed Tier 2 validation with mocked RMLMapper."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="Error: Column 'foo' not found in CSV",
         )
 
-        result = validate_node(state)
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            jar_path = jar_file.name
 
-        assert result.current_state == FlowState.ERROR
-        assert "CSV path required" in result.error_message
+        try:
+            validator = RMLValidator(rmlmapper_jar=jar_path)
+            result = validator.validate_with_rmlmapper(SAMPLE_RML, temp_csv)
 
-    def test_validate_node_syntax_valid(self, temp_csv):
-        """Test validate_node with valid RML syntax."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            csv_path=temp_csv,
-            generated_rml=SAMPLE_RML,
-            mapping_proposal=MappingProposal(status="approved"),
+            assert result.valid is False
+            assert result.error_category == "missing_column"
+            assert result.user_friendly_error is not None
+        finally:
+            os.unlink(jar_path)
+
+
+class TestSampleCSVExtraction:
+    """Tests for _extract_sample_csv and _get_rml_source_filename."""
+
+    def test_correct_filename_from_rml(self):
+        """Test that source filename is parsed from RML content."""
+        filename = RMLValidator._get_rml_source_filename(
+            SAMPLE_RML, "/path/to/other.csv"
+        )
+        assert filename == "data.csv"
+
+    def test_fallback_to_csv_path(self):
+        """Test fallback to csv_path basename when RML has no source."""
+        rml_no_source = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
+ex:Map rr:subjectMap [ ] .
+"""
+        filename = RMLValidator._get_rml_source_filename(
+            rml_no_source, "/path/to/mydata.csv"
+        )
+        assert filename == "mydata.csv"
+
+    def test_sample_csv_row_count(self, temp_csv):
+        """Test that sample CSV has the correct number of rows."""
+        validator = RMLValidator()
+        tmpdir = validator._extract_sample_csv(SAMPLE_RML, temp_csv, sample_rows=3)
+
+        try:
+            sample_path = Path(tmpdir.name) / "data.csv"
+            assert sample_path.exists()
+
+            with open(sample_path, "r") as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+
+            # Header + 3 data rows = 4
+            assert len(rows) == 4
+            assert rows[0] == ["year", "region", "value"]
+        finally:
+            tmpdir.cleanup()
+
+    def test_sample_csv_default_rows(self, temp_csv):
+        """Test default sample size (5 rows)."""
+        validator = RMLValidator()
+        tmpdir = validator._extract_sample_csv(SAMPLE_RML, temp_csv)
+
+        try:
+            sample_path = Path(tmpdir.name) / "data.csv"
+            with open(sample_path, "r") as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+
+            # Header + 5 data rows = 6
+            assert len(rows) == 6
+        finally:
+            tmpdir.cleanup()
+
+    def test_semicolon_delimiter(self, temp_csv_semicolon):
+        """Test that semicolon delimiters are preserved."""
+        rml_with_source = SAMPLE_RML  # Uses "data.csv" but we'll use our fixture
+        # Override the source filename to match
+        rml_custom = SAMPLE_RML.replace('rml:source "data.csv"', 'rml:source "test.csv"')
+
+        validator = RMLValidator()
+        tmpdir = validator._extract_sample_csv(
+            rml_custom, temp_csv_semicolon, sample_rows=2
         )
 
-        result = validate_node(state)
+        try:
+            sample_path = Path(tmpdir.name) / "test.csv"
+            assert sample_path.exists()
 
-        assert result.current_state == FlowState.PREVIEW
-        assert result.validation_error is None
+            with open(sample_path, "r") as f:
+                content = f.read()
 
-    def test_validate_node_syntax_invalid(self, temp_csv):
-        """Test validate_node with invalid RML syntax."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            csv_path=temp_csv,
-            generated_rml=INVALID_RML_SYNTAX,
-            mapping_proposal=MappingProposal(status="approved"),
+            # Should contain semicolons (preserved delimiter)
+            assert ";" in content
+
+            # Parse and check row count
+            with open(sample_path, "r") as f:
+                reader = csv.reader(f, delimiter=";")
+                rows = list(reader)
+
+            assert len(rows) == 3  # header + 2 data rows
+        finally:
+            tmpdir.cleanup()
+
+    def test_small_csv_fewer_rows_than_requested(self):
+        """Test extraction from CSV with fewer rows than requested."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as f:
+            f.write("a,b\n")
+            f.write("1,2\n")
+            csv_path = f.name
+
+        try:
+            validator = RMLValidator()
+            tmpdir = validator._extract_sample_csv(
+                SAMPLE_RML, csv_path, sample_rows=10
+            )
+
+            try:
+                sample_path = Path(tmpdir.name) / "data.csv"
+                with open(sample_path, "r") as f:
+                    reader = csv.reader(f)
+                    rows = list(reader)
+
+                # Only header + 1 row available
+                assert len(rows) == 2
+            finally:
+                tmpdir.cleanup()
+        finally:
+            os.unlink(csv_path)
+
+
+class TestErrorCategorization:
+    """Tests for _categorize_error."""
+
+    def test_missing_column(self):
+        """Test categorisation of missing column errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Error: Column 'population' not found in CSV"
         )
+        assert category == "missing_column"
+        assert "column" in desc.lower()
 
-        result = validate_node(state)
-
-        assert result.current_state == FlowState.REFINE
-        assert result.validation_error is not None
-        assert result.mapping_proposal.status == "refining"
-
-    def test_validate_node_adds_success_message(self, temp_csv):
-        """Test validate_node adds success message to conversation."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            csv_path=temp_csv,
-            generated_rml=SAMPLE_RML,
-            mapping_proposal=MappingProposal(status="approved"),
+    def test_invalid_iri(self):
+        """Test categorisation of invalid IRI errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Error: Invalid IRI generated from template"
         )
+        assert category == "invalid_iri"
+        assert "iri" in desc.lower() or "uri" in desc.lower()
 
-        result = validate_node(state)
-
-        # Check that a success message was added
-        assert len(result.messages) > 0
-        last_message = result.messages[-1]
-        assert last_message["role"] == "assistant"
-        assert "validation successful" in last_message["content"].lower()
-
-    def test_validate_node_adds_error_message(self, temp_csv):
-        """Test validate_node adds error message on failure."""
-        state = GraphState(
-            current_state=FlowState.GENERATE,
-            csv_path=temp_csv,
-            generated_rml=INVALID_RML_SYNTAX,
-            mapping_proposal=MappingProposal(status="approved"),
+    def test_type_mismatch(self):
+        """Test categorisation of type mismatch errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Error: Type mismatch — cannot cast 'abc' to xsd:integer"
         )
+        assert category == "type_mismatch"
+        assert "type" in desc.lower()
 
-        result = validate_node(state)
+    def test_file_not_found(self):
+        """Test categorisation of file not found errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Error: File not found: data.csv"
+        )
+        assert category == "file_not_found"
+        assert "file" in desc.lower()
 
-        # Check that an error message was added
-        assert len(result.messages) > 0
-        last_message = result.messages[-1]
-        assert last_message["role"] == "assistant"
-        assert "validation failed" in last_message["content"].lower()
+    def test_syntax_error(self):
+        """Test categorisation of syntax errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Parse error at line 5: unexpected token"
+        )
+        assert category == "syntax_error"
+
+    def test_unknown_error(self):
+        """Test categorisation of unrecognised errors."""
+        category, desc = RMLValidator._categorize_error(
+            "Something completely unexpected happened"
+        )
+        assert category == "unknown"
+        assert "Something completely unexpected" in desc
+
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -18,95 +18,17 @@ from ogd_to_lod.validation import (
 )
 
 
-# Sample RML for testing
-SAMPLE_RML = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
-@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
-@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix schema: <http://schema.org/> .
-@prefix cube: <https://cube.link/> .
-@prefix ex: <https://example.org/> .
-
-ex:TriplesMap a rr:TriplesMap ;
-    rml:logicalSource [
-        rml:source "data.csv" ;
-        rml:referenceFormulation ql:CSV
-    ] ;
-    rr:subjectMap [
-        rr:template "https://example.org/observation/{year}/{region}" ;
-        rr:class cube:Observation
-    ] ;
-    rr:predicateObjectMap [
-        rr:predicate cube:dimension ;
-        rr:objectMap [
-            rml:reference "year" ;
-            rr:datatype xsd:gYear
-        ]
-    ] ;
-    rr:predicateObjectMap [
-        rr:predicate cube:dimension ;
-        rr:objectMap [
-            rml:reference "region" ;
-            rr:datatype xsd:string
-        ]
-    ] ;
-    rr:predicateObjectMap [
-        rr:predicate cube:measure ;
-        rr:objectMap [
-            rml:reference "value" ;
-            rr:datatype xsd:decimal
-        ]
-    ] .
-"""
-
-# Invalid RML (syntax error)
+# Constants used only in this file
 INVALID_RML_SYNTAX = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
 This is not valid Turtle syntax!!!
 """
 
-# RML missing components (valid syntax but missing logical source)
 MINIMAL_RML = """@prefix rr: <http://www.w3.org/ns/r2rml#> .
 @prefix rml: <http://semweb.mmlab.be/ns/rml#> .
 @prefix ex: <http://example.org/> .
 
 ex:Something rr:predicateObjectMap [ ] .
 """
-
-
-@pytest.fixture
-def temp_csv():
-    """Create a temporary CSV file for testing."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".csv", delete=False
-    ) as f:
-        f.write("year,region,value\n")
-        f.write("2020,North,100.5\n")
-        f.write("2021,South,200.3\n")
-        f.write("2022,East,300.1\n")
-        f.write("2023,West,400.7\n")
-        f.write("2024,North,500.2\n")
-        f.write("2025,South,600.9\n")
-        f.write("2026,East,700.4\n")
-        csv_path = f.name
-    # File is now closed and flushed
-    yield csv_path
-    os.unlink(csv_path)
-
-
-@pytest.fixture
-def temp_csv_semicolon():
-    """Create a temporary semicolon-delimited CSV file."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".csv", delete=False
-    ) as f:
-        f.write("year;region;value\n")
-        f.write("2020;North;100.5\n")
-        f.write("2021;South;200.3\n")
-        f.write("2022;East;300.1\n")
-        csv_path = f.name
-    # File is now closed and flushed
-    yield csv_path
-    os.unlink(csv_path)
 
 
 class TestRMLValidator:
@@ -135,10 +57,10 @@ class TestRMLValidator:
         validator = RMLValidator()
         assert validator._rmlmapper_jar == "/env/path/rmlmapper.jar"
 
-    def test_validate_syntax_only_valid(self):
+    def test_validate_syntax_only_valid(self, sample_rml):
         """Test syntax-only validation with valid RML."""
         validator = RMLValidator()  # No JAR configured
-        result = validator.validate(SAMPLE_RML, "/nonexistent/path.csv")
+        result = validator.validate(sample_rml, "/nonexistent/path.csv")
 
         assert result.valid is True
         assert result.rdf_output is None  # No actual RDF generation
@@ -165,7 +87,7 @@ class TestRMLValidator:
             for w in result.warnings
         )
 
-    def test_validate_csv_not_found(self):
+    def test_validate_csv_not_found(self, sample_rml):
         """Test validation fails when CSV doesn't exist."""
         with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
             jar_path = jar_file.name
@@ -173,7 +95,7 @@ class TestRMLValidator:
         try:
             validator = RMLValidator(rmlmapper_jar=jar_path)
             result = validator.validate_with_rmlmapper(
-                SAMPLE_RML, "/nonexistent/data.csv"
+                sample_rml, "/nonexistent/data.csv"
             )
 
             assert result.valid is False
@@ -182,7 +104,7 @@ class TestRMLValidator:
             os.unlink(jar_path)
 
     @patch("subprocess.run")
-    def test_validate_with_jar_success(self, mock_run, temp_csv):
+    def test_validate_with_jar_success(self, mock_run, data_csv, sample_rml):
         """Test successful validation with JAR."""
         # Mock successful RMLMapper execution
         mock_run.return_value = subprocess.CompletedProcess(
@@ -201,7 +123,7 @@ class TestRMLValidator:
             # Need to mock the output file creation
             with patch.object(Path, "read_text", return_value="<rdf output>"):
                 with patch.object(Path, "exists", return_value=True):
-                    result = validator.validate(SAMPLE_RML, temp_csv)
+                    result = validator.validate(sample_rml, data_csv)
 
             assert result.valid is True
             assert mock_run.called
@@ -209,7 +131,7 @@ class TestRMLValidator:
             os.unlink(jar_path)
 
     @patch("subprocess.run")
-    def test_validate_with_jar_failure(self, mock_run, temp_csv):
+    def test_validate_with_jar_failure(self, mock_run, data_csv, sample_rml):
         """Test validation failure with JAR."""
         # Mock failed RMLMapper execution
         mock_run.return_value = subprocess.CompletedProcess(
@@ -224,7 +146,7 @@ class TestRMLValidator:
 
         try:
             validator = RMLValidator(rmlmapper_jar=jar_path)
-            result = validator.validate(SAMPLE_RML, temp_csv)
+            result = validator.validate(sample_rml, data_csv)
 
             assert result.valid is False
             assert "unknown_column" in result.error_message
@@ -232,7 +154,7 @@ class TestRMLValidator:
             os.unlink(jar_path)
 
     @patch("subprocess.run")
-    def test_validate_timeout(self, mock_run, temp_csv):
+    def test_validate_timeout(self, mock_run, data_csv, sample_rml):
         """Test validation timeout handling."""
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="java", timeout=60)
 
@@ -241,7 +163,7 @@ class TestRMLValidator:
 
         try:
             validator = RMLValidator(rmlmapper_jar=jar_path)
-            result = validator.validate(SAMPLE_RML, temp_csv, timeout=60)
+            result = validator.validate(sample_rml, data_csv, timeout=60)
 
             assert result.valid is False
             assert "timed out" in result.error_message.lower()
@@ -339,9 +261,9 @@ class TestValidationResult:
 class TestValidateRMLFunction:
     """Tests for the validate_rml convenience function."""
 
-    def test_validate_rml_syntax_only(self):
+    def test_validate_rml_syntax_only(self, sample_rml):
         """Test convenience function with syntax-only validation."""
-        result = validate_rml(SAMPLE_RML, "/nonexistent/path.csv")
+        result = validate_rml(sample_rml, "/nonexistent/path.csv")
 
         assert result.valid is True
 
@@ -349,10 +271,10 @@ class TestValidateRMLFunction:
 class TestValidateSyntax:
     """Tests for the public validate_syntax() method (Tier 1)."""
 
-    def test_valid_turtle(self):
+    def test_valid_turtle(self, sample_rml):
         """Test syntax validation passes for valid Turtle."""
         validator = RMLValidator()
-        result = validator.validate_syntax(SAMPLE_RML)
+        result = validator.validate_syntax(sample_rml)
 
         assert result.valid is True
         assert result.error_message is None
@@ -387,25 +309,25 @@ class TestValidateSyntax:
 class TestValidateWithRMLMapper:
     """Tests for validate_with_rmlmapper() method (Tier 2)."""
 
-    def test_skips_when_no_jar_configured(self):
+    def test_skips_when_no_jar_configured(self, sample_rml):
         """Test Tier 2 gracefully skips when RMLMapper is not configured."""
         validator = RMLValidator()  # No JAR
-        result = validator.validate_with_rmlmapper(SAMPLE_RML, "/some/path.csv")
+        result = validator.validate_with_rmlmapper(sample_rml, "/some/path.csv")
 
         assert result.valid is True
         assert result.warnings is not None
         assert any("skipped" in w.lower() for w in result.warnings)
 
-    def test_skips_when_jar_not_found(self):
+    def test_skips_when_jar_not_found(self, sample_rml):
         """Test Tier 2 gracefully skips when JAR file doesn't exist."""
         validator = RMLValidator(rmlmapper_jar="/nonexistent/rmlmapper.jar")
-        result = validator.validate_with_rmlmapper(SAMPLE_RML, "/some/path.csv")
+        result = validator.validate_with_rmlmapper(sample_rml, "/some/path.csv")
 
         assert result.valid is True
         assert result.warnings is not None
         assert any("not found" in w.lower() for w in result.warnings)
 
-    def test_csv_not_found(self):
+    def test_csv_not_found(self, sample_rml):
         """Test Tier 2 fails when CSV file doesn't exist."""
         with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
             jar_path = jar_file.name
@@ -413,7 +335,7 @@ class TestValidateWithRMLMapper:
         try:
             validator = RMLValidator(rmlmapper_jar=jar_path)
             result = validator.validate_with_rmlmapper(
-                SAMPLE_RML, "/nonexistent/data.csv"
+                sample_rml, "/nonexistent/data.csv"
             )
 
             assert result.valid is False
@@ -422,7 +344,7 @@ class TestValidateWithRMLMapper:
             os.unlink(jar_path)
 
     @patch("subprocess.run")
-    def test_success_with_mocked_rmlmapper(self, mock_run, temp_csv):
+    def test_success_with_mocked_rmlmapper(self, mock_run, data_csv, sample_rml):
         """Test successful Tier 2 validation with mocked RMLMapper."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -439,7 +361,7 @@ class TestValidateWithRMLMapper:
             with patch.object(Path, "read_text", return_value="<rdf>"):
                 with patch.object(Path, "exists", return_value=True):
                     result = validator.validate_with_rmlmapper(
-                        SAMPLE_RML, temp_csv
+                        sample_rml, data_csv
                     )
 
             assert result.valid is True
@@ -448,7 +370,7 @@ class TestValidateWithRMLMapper:
             os.unlink(jar_path)
 
     @patch("subprocess.run")
-    def test_failure_with_mocked_rmlmapper(self, mock_run, temp_csv):
+    def test_failure_with_mocked_rmlmapper(self, mock_run, data_csv, sample_rml):
         """Test failed Tier 2 validation with mocked RMLMapper."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -462,7 +384,7 @@ class TestValidateWithRMLMapper:
 
         try:
             validator = RMLValidator(rmlmapper_jar=jar_path)
-            result = validator.validate_with_rmlmapper(SAMPLE_RML, temp_csv)
+            result = validator.validate_with_rmlmapper(sample_rml, data_csv)
 
             assert result.valid is False
             assert result.error_category == "missing_column"
@@ -474,10 +396,10 @@ class TestValidateWithRMLMapper:
 class TestSampleCSVExtraction:
     """Tests for _extract_sample_csv and _get_rml_source_filename."""
 
-    def test_correct_filename_from_rml(self):
+    def test_correct_filename_from_rml(self, sample_rml):
         """Test that source filename is parsed from RML content."""
         filename = RMLValidator._get_rml_source_filename(
-            SAMPLE_RML, "/path/to/other.csv"
+            sample_rml, "/path/to/other.csv"
         )
         assert filename == "data.csv"
 
@@ -491,10 +413,10 @@ ex:Map rr:subjectMap [ ] .
         )
         assert filename == "mydata.csv"
 
-    def test_sample_csv_row_count(self, temp_csv):
+    def test_sample_csv_row_count(self, data_csv, sample_rml):
         """Test that sample CSV has the correct number of rows."""
         validator = RMLValidator()
-        tmpdir = validator._extract_sample_csv(SAMPLE_RML, temp_csv, sample_rows=3)
+        tmpdir = validator._extract_sample_csv(sample_rml, data_csv, sample_rows=3)
 
         try:
             sample_path = Path(tmpdir.name) / "data.csv"
@@ -510,10 +432,10 @@ ex:Map rr:subjectMap [ ] .
         finally:
             tmpdir.cleanup()
 
-    def test_sample_csv_default_rows(self, temp_csv):
+    def test_sample_csv_default_rows(self, data_csv, sample_rml):
         """Test default sample size (5 rows)."""
         validator = RMLValidator()
-        tmpdir = validator._extract_sample_csv(SAMPLE_RML, temp_csv)
+        tmpdir = validator._extract_sample_csv(sample_rml, data_csv)
 
         try:
             sample_path = Path(tmpdir.name) / "data.csv"
@@ -526,15 +448,14 @@ ex:Map rr:subjectMap [ ] .
         finally:
             tmpdir.cleanup()
 
-    def test_semicolon_delimiter(self, temp_csv_semicolon):
+    def test_semicolon_delimiter(self, semicolon_csv, sample_rml):
         """Test that semicolon delimiters are preserved."""
-        rml_with_source = SAMPLE_RML  # Uses "data.csv" but we'll use our fixture
         # Override the source filename to match
-        rml_custom = SAMPLE_RML.replace('rml:source "data.csv"', 'rml:source "test.csv"')
+        rml_custom = sample_rml.replace('rml:source "data.csv"', 'rml:source "test.csv"')
 
         validator = RMLValidator()
         tmpdir = validator._extract_sample_csv(
-            rml_custom, temp_csv_semicolon, sample_rows=2
+            rml_custom, semicolon_csv, sample_rows=2
         )
 
         try:
@@ -556,33 +477,23 @@ ex:Map rr:subjectMap [ ] .
         finally:
             tmpdir.cleanup()
 
-    def test_small_csv_fewer_rows_than_requested(self):
+    def test_small_csv_fewer_rows_than_requested(self, small_csv, sample_rml):
         """Test extraction from CSV with fewer rows than requested."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".csv", delete=False
-        ) as f:
-            f.write("a,b\n")
-            f.write("1,2\n")
-            csv_path = f.name
+        validator = RMLValidator()
+        tmpdir = validator._extract_sample_csv(
+            sample_rml, small_csv, sample_rows=10
+        )
 
         try:
-            validator = RMLValidator()
-            tmpdir = validator._extract_sample_csv(
-                SAMPLE_RML, csv_path, sample_rows=10
-            )
+            sample_path = Path(tmpdir.name) / "data.csv"
+            with open(sample_path, "r") as f:
+                reader = csv.reader(f)
+                rows = list(reader)
 
-            try:
-                sample_path = Path(tmpdir.name) / "data.csv"
-                with open(sample_path, "r") as f:
-                    reader = csv.reader(f)
-                    rows = list(reader)
-
-                # Only header + 1 row available
-                assert len(rows) == 2
-            finally:
-                tmpdir.cleanup()
+            # Only header + 1 row available
+            assert len(rows) == 2
         finally:
-            os.unlink(csv_path)
+            tmpdir.cleanup()
 
 
 class TestErrorCategorization:
@@ -636,3 +547,56 @@ class TestErrorCategorization:
         assert "Something completely unexpected" in desc
 
 
+@pytest.mark.integration
+class TestIntegrationRMLMapper:
+    """Integration tests that exercise the real RMLMapper JAR.
+
+    These tests require:
+    - tools/rmlmapper.jar to be present (run scripts/setup-rmlmapper.sh)
+    - Java runtime on PATH
+
+    Skip with: pytest -m "not integration"
+    """
+
+    def test_valid_rml_produces_rdf(self, rmlmapper_available, data_csv, sample_rml):
+        """Tier 2 with real JAR — success path, asserts RDF output."""
+        validator = RMLValidator(rmlmapper_jar=rmlmapper_available)
+        result = validator.validate_with_rmlmapper(sample_rml, data_csv)
+
+        assert result.valid is True
+        assert result.rdf_output is not None
+        assert len(result.rdf_output.strip()) > 0
+        # The output should contain RDF triples referencing our data
+        assert "example.org" in result.rdf_output
+
+    def test_full_validate_chain(self, rmlmapper_available, data_csv, sample_rml):
+        """validate() runs both Tier 1 + Tier 2 end-to-end."""
+        validator = RMLValidator(rmlmapper_jar=rmlmapper_available)
+        result = validator.validate(sample_rml, data_csv)
+
+        assert result.valid is True
+        assert result.rdf_output is not None
+
+    def test_missing_column_error(self, rmlmapper_available, data_csv, sample_rml):
+        """RML referencing a nonexistent column produces valid=False."""
+        bad_rml = sample_rml.replace('rml:reference "year"', 'rml:reference "nonexistent"')
+        validator = RMLValidator(rmlmapper_jar=rmlmapper_available)
+        result = validator.validate_with_rmlmapper(bad_rml, data_csv)
+
+        # RMLMapper should fail or produce empty output for bad column refs.
+        # Behaviour depends on RMLMapper version — some silently skip, others error.
+        # At minimum, the result should not crash.
+        assert isinstance(result, ValidationResult)
+
+    def test_small_csv_works(self, rmlmapper_available, small_csv, sample_rml):
+        """1-row CSV still produces valid RDF."""
+        validator = RMLValidator(rmlmapper_jar=rmlmapper_available)
+        result = validator.validate_with_rmlmapper(sample_rml, small_csv)
+
+        assert result.valid is True
+        assert result.rdf_output is not None
+
+    def test_is_available_with_real_jar(self, rmlmapper_available):
+        """is_available() returns True when the real JAR is present."""
+        validator = RMLValidator(rmlmapper_jar=rmlmapper_available)
+        assert validator.is_available() is True

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -393,6 +393,161 @@ class TestValidateWithRMLMapper:
             os.unlink(jar_path)
 
 
+class TestIsEmptyRDFOutput:
+    """Tests for _is_empty_rdf_output static helper."""
+
+    def test_prefix_only_output(self):
+        """Output with only @prefix declarations is empty."""
+        output = (
+            '@prefix rml: <http://w3id.org/rml/> .\n'
+            '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n'
+            '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is True
+
+    def test_prefix_and_base_only(self):
+        """Output with @prefix and @base is still empty."""
+        output = (
+            '@base <http://example.org/> .\n'
+            '@prefix ex: <http://example.org/> .\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is True
+
+    def test_sparql_style_declarations(self):
+        """SPARQL-style PREFIX/BASE declarations are also empty."""
+        output = (
+            'PREFIX ex: <http://example.org/>\n'
+            'BASE <http://example.org/>\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is True
+
+    def test_blank_string(self):
+        """Completely empty string is empty."""
+        assert RMLValidator._is_empty_rdf_output("") is True
+
+    def test_whitespace_only(self):
+        """Whitespace-only output is empty."""
+        assert RMLValidator._is_empty_rdf_output("  \n  \n") is True
+
+    def test_comments_only(self):
+        """Output with only comments (and prefixes) is empty."""
+        output = (
+            '# This is a comment\n'
+            '@prefix ex: <http://example.org/> .\n'
+            '# Another comment\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is True
+
+    def test_output_with_triples(self):
+        """Output with actual triples is NOT empty."""
+        output = (
+            '@prefix ex: <http://example.org/> .\n'
+            '\n'
+            'ex:subject ex:predicate "value" .\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is False
+
+    def test_output_with_blank_node(self):
+        """Output with blank node triples is NOT empty."""
+        output = (
+            '@prefix ex: <http://example.org/> .\n'
+            '\n'
+            '_:b0 ex:predicate "value" .\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is False
+
+    def test_realistic_rmlmapper_empty(self):
+        """Realistic RMLMapper output that is empty (from user's report)."""
+        output = (
+            '@prefix cube: <https://cube.link/> .\n'
+            '@prefix ex: <https://ld.stadt-zuerich.ch/statistics/> .\n'
+            '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n'
+            '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n'
+            '@prefix rml: <http://w3id.org/rml/> .\n'
+            '@prefix schema: <http://schema.org/> .\n'
+            '@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n'
+        )
+        assert RMLValidator._is_empty_rdf_output(output) is True
+
+
+class TestProcessResultEmptyOutput:
+    """Tests for _process_result detecting empty RMLMapper output."""
+
+    def test_prefix_only_output_is_invalid(self):
+        """_process_result returns valid=False when output has only prefixes."""
+        prefix_only = (
+            '@prefix ex: <http://example.org/> .\n'
+            '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n'
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ttl", delete=False
+        ) as f:
+            f.write(prefix_only)
+            output_path = Path(f.name)
+
+        try:
+            validator = RMLValidator()
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr="",
+            )
+            result = validator._process_result(completed, output_path)
+
+            assert result.valid is False
+            assert result.error_category == "empty_output"
+            assert "no output triples" in result.error_message.lower()
+            assert result.user_friendly_error is not None
+        finally:
+            output_path.unlink()
+
+    def test_output_with_triples_is_valid(self):
+        """_process_result returns valid=True when output contains triples."""
+        rdf_with_data = (
+            '@prefix ex: <http://example.org/> .\n'
+            '\n'
+            'ex:obs1 a ex:Observation ;\n'
+            '  ex:value "42" .\n'
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ttl", delete=False
+        ) as f:
+            f.write(rdf_with_data)
+            output_path = Path(f.name)
+
+        try:
+            validator = RMLValidator()
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr="",
+            )
+            result = validator._process_result(completed, output_path)
+
+            assert result.valid is True
+            assert result.rdf_output == rdf_with_data
+        finally:
+            output_path.unlink()
+
+    def test_empty_file_is_invalid(self):
+        """_process_result returns valid=False for a completely empty file."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ttl", delete=False
+        ) as f:
+            f.write("")
+            output_path = Path(f.name)
+
+        try:
+            validator = RMLValidator()
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr="",
+            )
+            result = validator._process_result(completed, output_path)
+
+            assert result.valid is False
+            assert result.error_category == "empty_output"
+        finally:
+            output_path.unlink()
+
+
 class TestSampleCSVExtraction:
     """Tests for _extract_sample_csv and _get_rml_source_filename."""
 


### PR DESCRIPTION
## Summary

- Split RML validation into **Tier 1** (rdflib syntax check, auto-retried up to 3×) and **Tier 2** (RMLMapper against sample CSV data, escalated to user on failure)
- Add error categorisation with user-friendly messages for common RMLMapper failures (missing column, invalid IRI, type mismatch, etc.)
- **Detect empty RMLMapper output** (only prefix declarations, no data triples) as a validation failure with `error_category="empty_output"` — this catches cases where column references don't match the CSV (e.g. wrong delimiter) and RMLMapper silently produces zero triples
- Add sample CSV extraction so RMLMapper validates against the first N rows rather than the full file
- Add `scripts/setup-rmlmapper.sh` to download the latest RMLMapper JAR
- Add `rdf:` and `rdfs:` to `RML_GENERATION_PROMPT` prefix list to prevent undeclared-prefix errors
- Make Tier 1 retries **error-aware**: on syntax failure, the actual error is sent back to the AI via `RML_CORRECTION_PROMPT` instead of blindly re-running the original generation prompt
- Add `ensure_common_prefixes()` safety net that auto-injects missing well-known `@prefix` declarations (rdf, rdfs, owl, skos, dcterms, schema, foaf)
- Update project documentation (README, CLAUDE.md) with current CLI options and project structure

## Test plan

- [x] All 58 validation tests pass (`pytest tests/test_validation.py -v`)
- [x] All 30 RML tests pass (`pytest tests/test_rml.py -v`)
- [x] Full suite passes (260 tests, 0 failures)
- [x] Manual test: `ogd-to-lod --out data/mapping.ttl data/data.csv data/dcat.ttl` no longer fails on missing `rdfs:` prefix
- [x] Empty RMLMapper output (prefix-only) is correctly flagged as `valid=False`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
