### PR TITLE
SPARQL-based reuse of cube.link properties and DefinedTerms (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,31 +55,9 @@ ogd-to-lod/
 
 ## Development Workflow
 
-1. Create a feature branch from main (e.g., `feature/issue-2-csv-parser`)
-2. Work on issues from the GitHub issue tracker
+1. Create a feature branch from main (e.g., `feature/issue-37`)
+2. Work on issues sequentially — one issue at a time in the main repo directory
 3. Run tests with `pytest`
 4. Commit with descriptive messages referencing issue numbers
 5. Push branch and create a Pull Request to main
 6. Never commit directly to main branch
-
-### Working on Multiple Issues (Worktrees)
-
-To work on multiple issues in parallel, use git worktrees:
-
-```bash
-# Create a new worktree for an issue
-./scripts/setup-worktree.sh <issue-number>
-
-# Example: work on issue #12
-./scripts/setup-worktree.sh 12
-# Creates: ../ogd-to-lod-issue-12 with branch feature/issue-12
-```
-
-The script automatically symlinks `.env` and `.claude/` from the main repo.
-
-**Important**: After creating a worktree, open a new Claude Code session in that directory.
-
-```bash
-# Clean up when done
-git worktree remove ../ogd-to-lod-issue-<number>
-```

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -16,6 +16,7 @@ from .nodes import (
     generate_node,
     handle_user_input,
     init_node,
+    lookup_node,
     preview_node,
     propose_node,
     regenerate_node,
@@ -59,6 +60,8 @@ class MappingFlow:
         # Add nodes
         graph.add_node("init", self._wrap_init)
         graph.add_node("analyze", self._wrap_analyze)
+        graph.add_node("lookup", self._wrap_lookup)
+        graph.add_node("wait_for_lookup", self._wait_for_lookup)
         graph.add_node("propose", self._wrap_propose)
         graph.add_node("wait_for_input", self._wait_for_input)
         graph.add_node("process_input", self._wrap_process_input)
@@ -90,10 +93,22 @@ class MappingFlow:
             "analyze",
             self._route_from_analyze,
             {
-                "propose": "propose",
+                "lookup": "lookup",
                 "error": "error",
             },
         )
+
+        graph.add_conditional_edges(
+            "lookup",
+            self._route_from_lookup,
+            {
+                "propose": "propose",
+                "wait_for_lookup": "wait_for_lookup",
+                "error": "error",
+            },
+        )
+
+        graph.add_edge("wait_for_lookup", "lookup")
 
         graph.add_edge("propose", "wait_for_input")
 
@@ -172,6 +187,16 @@ class MappingFlow:
     def _wrap_analyze(self, state_dict: dict[str, Any]) -> dict[str, Any]:
         """Wrapper for analyze node."""
         self._state = analyze_node(self._state, self._config, self._ai_service)
+        return self._state.to_dict()
+
+    def _wrap_lookup(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Wrapper for lookup node."""
+        self._state = lookup_node(self._state, self._config)
+        return self._state.to_dict()
+
+    def _wait_for_lookup(self, state_dict: dict[str, Any]) -> dict[str, Any]:
+        """Node that waits for user confirmation of vocabulary reuse."""
+        self._state.awaiting_user_input = True
         return self._state.to_dict()
 
     def _wrap_propose(self, state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -281,6 +306,14 @@ class MappingFlow:
         """Route from ANALYZE state."""
         if self._state.current_state == FlowState.ERROR:
             return "error"
+        return "lookup"
+
+    def _route_from_lookup(self, state_dict: dict[str, Any]) -> str:
+        """Route from LOOKUP state."""
+        if self._state.current_state == FlowState.ERROR:
+            return "error"
+        if self._state.awaiting_user_input:
+            return "wait_for_lookup"
         return "propose"
 
     def _route_from_process_input(self, state_dict: dict[str, Any]) -> str:
@@ -389,6 +422,10 @@ class MappingFlow:
         self._state.user_input = user_input
         self._state.awaiting_user_input = False
 
+        # Handle vocabulary reuse confirmation if in LOOKUP state
+        if self._state.current_state == FlowState.LOOKUP:
+            return self._handle_lookup_confirmation(user_input)
+
         # Handle name confirmation if in CONFIRM_NAME state
         if self._state.current_state == FlowState.CONFIRM_NAME:
             return self._handle_name_confirmation(user_input)
@@ -492,6 +529,51 @@ class MappingFlow:
         self._state.current_state = FlowState.REFINE
         if self._state.mapping_proposal:
             self._state.mapping_proposal.status = "refining"
+
+    def _handle_lookup_confirmation(self, user_input: str) -> GraphState:
+        """Handle user yes/no confirmation of vocabulary reuse from SPARQL.
+
+        'yes' / 'y' — keep the ReuseContext and proceed to PROPOSE.
+        'no' / 'n' / 'skip' — clear the ReuseContext (use fresh URIs) and proceed.
+        Anything else — prompt again.
+
+        Args:
+            user_input: User's response.
+
+        Returns:
+            Updated state.
+        """
+        self._state.add_message("user", user_input)
+        answer = user_input.lower().strip()
+
+        if answer in ("yes", "y", "ja", "ok", "sure", "reuse"):
+            logger.info("User accepted vocabulary reuse from SPARQL")
+            self._state.add_message(
+                "assistant",
+                "Great, I will reuse the existing vocabulary URIs in the mapping.",
+            )
+            self._state.awaiting_user_input = False
+            self._state.current_state = FlowState.PROPOSE
+            self._state = propose_node(self._state, self._ai_service)
+        elif answer in ("no", "n", "nein", "skip", "fresh", "new"):
+            logger.info("User rejected vocabulary reuse — clearing reuse context")
+            from ogd_to_lod.lookup import ReuseContext
+            self._state.reuse_context = ReuseContext()
+            self._state.add_message(
+                "assistant",
+                "Understood, I will generate fresh URIs for all properties and code values.",
+            )
+            self._state.awaiting_user_input = False
+            self._state.current_state = FlowState.PROPOSE
+            self._state = propose_node(self._state, self._ai_service)
+        else:
+            self._state.awaiting_user_input = True
+            self._state.add_message(
+                "assistant",
+                "Please answer with 'yes' to reuse the existing URIs or 'no' to generate fresh ones.",
+            )
+
+        return self._state
 
     def _handle_name_confirmation(self, user_input: str) -> GraphState:
         """Handle user confirmation of the mapping name.
@@ -629,6 +711,13 @@ class MappingFlow:
     def has_rdf_preview(self) -> bool:
         """Check if an RDF preview is available."""
         return self._state.rdf_preview is not None
+
+    def is_awaiting_lookup_confirmation(self) -> bool:
+        """Check if flow is waiting for vocabulary reuse confirmation."""
+        return (
+            self._state.current_state == FlowState.LOOKUP
+            and self._state.awaiting_user_input
+        )
 
     def is_awaiting_name_confirmation(self) -> bool:
         """Check if flow is waiting for mapping name confirmation."""

--- a/src/ogd_to_lod/graph/nodes.py
+++ b/src/ogd_to_lod/graph/nodes.py
@@ -9,6 +9,7 @@ import yaml
 from ogd_to_lod.ai import AIService
 from ogd_to_lod.config import Config
 from ogd_to_lod.github import GitHubService, PRCreationError
+from ogd_to_lod.lookup import ReuseContext, SPARQLLookup
 from ogd_to_lod.github.pr_template import (
     build_csv_preview_section,
     build_mapping_structure_section,
@@ -146,9 +147,70 @@ def analyze_node(state: GraphState, config: Config, ai_service: Any | None = Non
     # Build summary
     state.parsed_summary = _build_summary(state.csv_schema, state.dataset_context)
 
-    # Transition to PROPOSE
-    state.current_state = FlowState.PROPOSE
-    logger.info("Transitioning to PROPOSE state")
+    # Transition to LOOKUP
+    state.current_state = FlowState.LOOKUP
+    logger.info("Transitioning to LOOKUP state")
+
+    return state
+
+
+def lookup_node(state: GraphState, config: Config) -> GraphState:
+    """Look up existing cube.link properties and DefinedTerms via SPARQL.
+
+    When no SPARQL endpoint is configured, silently skips to PROPOSE.
+    When matches are found, stores them in state.reuse_context and
+    presents them to the user for confirmation.
+
+    Args:
+        state: Current graph state with parsed CSV schema.
+        config: Application configuration (SPARQL endpoint URL).
+
+    Returns:
+        Updated state.
+    """
+    logger.info("Entering LOOKUP state")
+
+    endpoint = config.sparql.endpoint if config.sparql else None
+
+    if not endpoint:
+        logger.info("No SPARQL endpoint configured — skipping vocabulary lookup")
+        state.reuse_context = ReuseContext()
+        state.current_state = FlowState.PROPOSE
+        return state
+
+    if not state.csv_schema:
+        logger.warning("No CSV schema available for SPARQL lookup — skipping")
+        state.reuse_context = ReuseContext()
+        state.current_state = FlowState.PROPOSE
+        return state
+
+    logger.info("Querying SPARQL endpoint: %s", endpoint)
+    lookup = SPARQLLookup(endpoint)
+
+    proposal_dict = state.mapping_proposal.to_dict() if state.mapping_proposal else None
+    context = lookup.build_reuse_context(state.csv_schema, proposal_dict)
+    state.reuse_context = context
+
+    if not context.has_matches():
+        logger.info("No reusable vocabulary found — proceeding to PROPOSE")
+        state.current_state = FlowState.PROPOSE
+        return state
+
+    # Present matches to user for confirmation
+    display = context.to_display_text()
+    msg = (
+        f"Found existing vocabulary resources in the SPARQL endpoint:\n\n{display}\n\n"
+        "Reuse these existing URIs in the mapping? "
+        "(yes = reuse them, no = generate fresh URIs)"
+    )
+    state.add_message("assistant", msg)
+    state.current_state = FlowState.LOOKUP
+    state.awaiting_user_input = True
+    logger.info(
+        "Found %d property and %d DefinedTermSet matches — awaiting user confirmation",
+        len(context.properties),
+        len(context.defined_term_sets),
+    )
 
     return state
 
@@ -377,6 +439,7 @@ def generate_node(state: GraphState, ai_service: AIService) -> GraphState:
             csv_path=state.csv_path,
             base_uri=state.base_uri,
             dataset_context=state.dataset_context,
+            reuse_context=state.reuse_context,
         )
 
         state.generated_rml = rml_content

--- a/src/ogd_to_lod/graph/state.py
+++ b/src/ogd_to_lod/graph/state.py
@@ -4,12 +4,15 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from ogd_to_lod.lookup import ReuseContext
+
 
 class FlowState(Enum):
     """Possible states in the conversation flow."""
 
     INIT = "init"
     ANALYZE = "analyze"
+    LOOKUP = "lookup"
     PROPOSE = "propose"
     REFINE = "refine"
     GENERATE = "generate"
@@ -117,6 +120,9 @@ class GraphState:
     dataset_context: dict[str, Any] | None = None
     parsed_summary: str | None = None
 
+    # Vocabulary reuse context (populated in LOOKUP state)
+    reuse_context: ReuseContext | None = None
+
     # Mapping proposal (populated in PROPOSE state)
     mapping_proposal: MappingProposal | None = None
     proposal_text: str | None = None  # AI's explanation
@@ -178,6 +184,7 @@ class GraphState:
             "csv_schema": self.csv_schema,
             "dataset_context": self.dataset_context,
             "parsed_summary": self.parsed_summary,
+            "reuse_context": self.reuse_context.has_matches() if self.reuse_context else False,
             "mapping_proposal": self.mapping_proposal.to_dict() if self.mapping_proposal else None,
             "proposal_text": self.proposal_text,
             "user_input": self.user_input,

--- a/src/ogd_to_lod/lookup/__init__.py
+++ b/src/ogd_to_lod/lookup/__init__.py
@@ -1,0 +1,12 @@
+"""SPARQL-based vocabulary reuse lookup."""
+
+from .reuse_context import MatchedDefinedTermSet, MatchedProperty, ReuseContext
+from .sparql_client import SPARQLLookup, SPARQLLookupError
+
+__all__ = [
+    "SPARQLLookup",
+    "SPARQLLookupError",
+    "ReuseContext",
+    "MatchedProperty",
+    "MatchedDefinedTermSet",
+]

--- a/src/ogd_to_lod/lookup/reuse_context.py
+++ b/src/ogd_to_lod/lookup/reuse_context.py
@@ -1,0 +1,103 @@
+"""Data structures for SPARQL-based vocabulary reuse context."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MatchedProperty:
+    """An existing cube.link property found in the SPARQL endpoint."""
+
+    existing_uri: str
+    label: str
+    matched_column: str  # CSV column this was matched to
+
+
+@dataclass
+class MatchedDefinedTermSet:
+    """An existing schema:DefinedTermSet found in the SPARQL endpoint."""
+
+    term_set_uri: str
+    uri_template: str  # e.g. "https://ld.stadt-zuerich.ch/statistics/code/$(col)~iri"
+    matched_column: str
+    coverage: float  # fraction of CSV sample values found (0.0–1.0)
+    sample_matches: list[str] = field(default_factory=list)  # matched values from CSV sample
+
+
+@dataclass
+class ReuseContext:
+    """Vocabulary reuse context built from SPARQL lookups.
+
+    Carries existing property URIs and DefinedTermSet templates that should
+    be used in the YARRRML mapping instead of generating fresh ex-property:/ex-code: URIs.
+    """
+
+    properties: list[MatchedProperty] = field(default_factory=list)
+    defined_term_sets: list[MatchedDefinedTermSet] = field(default_factory=list)
+
+    def has_matches(self) -> bool:
+        """Return True if any reusable resources were found."""
+        return bool(self.properties or self.defined_term_sets)
+
+    def to_prompt_text(self) -> str:
+        """Format reuse context for injection into AI prompts."""
+        if not self.has_matches():
+            return ""
+
+        lines = ["## Existing Vocabulary (reuse from SPARQL endpoint)"]
+        lines.append(
+            "The following existing resources were found and MUST be reused in the mapping:"
+        )
+
+        if self.properties:
+            lines.append("")
+            lines.append("### Properties")
+            lines.append(
+                "Use these existing URIs as predicates instead of generating ex-property: names:"
+            )
+            for p in self.properties:
+                lines.append(
+                    f"- Column `{p.matched_column}` → use `<{p.existing_uri}>` "
+                    f"(label: {p.label})"
+                )
+
+        if self.defined_term_sets:
+            lines.append("")
+            lines.append("### DefinedTermSets")
+            lines.append(
+                "Use these URI templates for code values instead of ex-code:$(col)~iri:"
+            )
+            for d in self.defined_term_sets:
+                lines.append(
+                    f"- Column `{d.matched_column}` → use `{d.uri_template}` "
+                    f"(DefinedTermSet: <{d.term_set_uri}>, "
+                    f"coverage: {d.coverage:.0%})"
+                )
+            lines.append("")
+            lines.append(
+                "Do NOT generate a separate mapping for schema:DefinedTerm resources "
+                "for columns listed above — the DefinedTerms already exist."
+            )
+
+        return "\n".join(lines)
+
+    def to_display_text(self) -> str:
+        """Format reuse context for display to the user."""
+        if not self.has_matches():
+            return ""
+
+        lines = []
+
+        if self.properties:
+            lines.append(f"**{len(self.properties)} existing property/properties:**")
+            for p in self.properties:
+                lines.append(f"  - `{p.matched_column}` → `<{p.existing_uri}>`")
+
+        if self.defined_term_sets:
+            lines.append(f"**{len(self.defined_term_sets)} existing DefinedTermSet(s):**")
+            for d in self.defined_term_sets:
+                lines.append(
+                    f"  - `{d.matched_column}` → `<{d.term_set_uri}>` "
+                    f"({d.coverage:.0%} of sample values matched)"
+                )
+
+        return "\n".join(lines)

--- a/src/ogd_to_lod/lookup/sparql_client.py
+++ b/src/ogd_to_lod/lookup/sparql_client.py
@@ -1,0 +1,359 @@
+"""SPARQL-based lookup for existing cube.link properties and DefinedTerms."""
+
+from ogd_to_lod.logging import get_logger
+
+from .reuse_context import MatchedDefinedTermSet, MatchedProperty, ReuseContext
+
+logger = get_logger(__name__)
+
+# Minimum fraction of CSV sample values that must match a DefinedTermSet for it to be proposed
+MIN_COVERAGE = 0.5
+
+
+class SPARQLLookupError(Exception):
+    """Error during SPARQL lookup."""
+
+    pass
+
+
+class SPARQLLookup:
+    """Queries a SPARQL endpoint for existing cube.link properties and DefinedTerms.
+
+    Both query types are scoped to resources already present in cube.link-based
+    data cubes (cube:Observation subjects), so unrelated RDF data in the same
+    endpoint is ignored.
+    """
+
+    # Query 1: All properties used as predicates on cube:Observation subjects.
+    # Returns the property URI and an optional rdfs:label.
+    _PROPERTY_QUERY = """
+PREFIX cube: <https://cube.link/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?property ?label WHERE {{
+  ?obs a cube:Observation .
+  ?obs ?property ?value .
+  OPTIONAL {{ ?property rdfs:label ?label }}
+  FILTER(?property != rdf:type)
+}}
+"""
+
+    # Query 2: schema:DefinedTerm instances whose schema:name matches one of
+    # the supplied VALUES.  Also returns the schema:DefinedTermSet they belong to.
+    _DEFINED_TERM_QUERY = """
+PREFIX schema: <http://schema.org/>
+
+SELECT ?termSet ?term ?name WHERE {{
+  ?termSet a schema:DefinedTermSet .
+  ?term a schema:DefinedTerm ;
+        schema:isPartOf ?termSet ;
+        schema:name ?name .
+  VALUES ?name {{ {values} }}
+}}
+"""
+
+    def __init__(self, endpoint: str):
+        """Initialize with a SPARQL endpoint URL.
+
+        Args:
+            endpoint: SPARQL endpoint URL.
+        """
+        self._endpoint = endpoint
+
+    def build_reuse_context(
+        self,
+        csv_schema: dict,
+        mapping_proposal: dict | None = None,
+    ) -> ReuseContext:
+        """Run both lookups and return a ReuseContext.
+
+        Args:
+            csv_schema: Parsed CSV schema with column names, types and sample values.
+            mapping_proposal: Optional approved mapping proposal (used to restrict
+                              which columns are treated as dimensions/measures).
+
+        Returns:
+            ReuseContext with matched properties and DefinedTermSets.
+        """
+        context = ReuseContext()
+
+        try:
+            context.properties = self._lookup_properties(csv_schema, mapping_proposal)
+        except Exception as e:
+            logger.warning("Property SPARQL lookup failed: %s", e)
+
+        try:
+            context.defined_term_sets = self._lookup_defined_term_sets(csv_schema, mapping_proposal)
+        except Exception as e:
+            logger.warning("DefinedTermSet SPARQL lookup failed: %s", e)
+
+        return context
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _sparql_query(self, query: str) -> list[dict]:
+        """Execute a SPARQL SELECT query and return rows as dicts.
+
+        Args:
+            query: SPARQL SELECT query string.
+
+        Returns:
+            List of result rows, each a dict mapping variable name → value string.
+
+        Raises:
+            SPARQLLookupError: If the query fails.
+        """
+        try:
+            from SPARQLWrapper import JSON, SPARQLWrapper
+
+            sparql = SPARQLWrapper(self._endpoint)
+            sparql.setQuery(query)
+            sparql.setReturnFormat(JSON)
+            results = sparql.query().convert()
+
+            rows = []
+            for binding in results.get("results", {}).get("bindings", []):
+                row = {k: v.get("value", "") for k, v in binding.items()}
+                rows.append(row)
+            return rows
+
+        except ImportError as e:
+            raise SPARQLLookupError(
+                "SPARQLWrapper is not installed. "
+                "Install it with: pip install SPARQLWrapper"
+            ) from e
+        except Exception as e:
+            raise SPARQLLookupError(f"SPARQL query failed: {e}") from e
+
+    def _lookup_properties(
+        self,
+        csv_schema: dict,
+        mapping_proposal: dict | None,
+    ) -> list[MatchedProperty]:
+        """Find existing cube.link properties matching the CSV columns.
+
+        Fetches all cube:Observation predicates from the endpoint, then matches
+        them against the CSV column names by comparing rdfs:label (if present)
+        or the local name of the URI against the column name (case-insensitive).
+
+        Args:
+            csv_schema: CSV schema dict.
+            mapping_proposal: Optional mapping proposal.
+
+        Returns:
+            List of matched properties.
+        """
+        logger.debug("Looking up cube.link properties in SPARQL endpoint %s", self._endpoint)
+        rows = self._sparql_query(self._PROPERTY_QUERY)
+
+        if not rows:
+            logger.debug("No cube:Observation properties found in endpoint")
+            return []
+
+        # Build lookup: label/local_name → (uri, label)
+        endpoint_props: list[tuple[str, str, str]] = []  # (match_key, uri, label)
+        for row in rows:
+            uri = row.get("property", "")
+            label = row.get("label", "")
+            if not uri:
+                continue
+            # Use label for matching if available, otherwise fall back to local name
+            local_name = uri.split("/")[-1].split("#")[-1]
+            match_key = label if label else local_name
+            endpoint_props.append((match_key.lower(), uri, label or local_name))
+
+        # Determine which columns to match (all if no proposal)
+        column_names = [col["name"] for col in csv_schema.get("columns", [])]
+
+        matched: list[MatchedProperty] = []
+        for col_name in column_names:
+            col_lower = col_name.lower()
+            for match_key, uri, label in endpoint_props:
+                if match_key == col_lower:
+                    logger.info(
+                        "Matched column '%s' to existing property <%s>", col_name, uri
+                    )
+                    matched.append(
+                        MatchedProperty(
+                            existing_uri=uri,
+                            label=label,
+                            matched_column=col_name,
+                        )
+                    )
+                    break  # one match per column
+
+        logger.debug("Found %d property matches", len(matched))
+        return matched
+
+    def _lookup_defined_term_sets(
+        self,
+        csv_schema: dict,
+        mapping_proposal: dict | None,
+    ) -> list[MatchedDefinedTermSet]:
+        """Find existing DefinedTermSets that cover the categorical column values.
+
+        For each column whose sample values are looked up, a DefinedTermSet is
+        considered a match when:
+        - At least MIN_COVERAGE fraction of sample values are found as schema:DefinedTerm
+        - The DefinedTerm URIs share a common prefix, and the URI suffix equals the
+          CSV value exactly (enabling a simple template like ``{prefix}$(col)~iri``).
+
+        Args:
+            csv_schema: CSV schema dict.
+            mapping_proposal: Optional mapping proposal.
+
+        Returns:
+            List of matched DefinedTermSets.
+        """
+        # Determine which columns are categorical (skip temporal/numeric)
+        categorical_cols = self._get_categorical_columns(csv_schema, mapping_proposal)
+        if not categorical_cols:
+            return []
+
+        # Collect all unique sample values across categorical columns
+        all_values: dict[str, list[str]] = {}  # column → sample values
+        for col in csv_schema.get("columns", []):
+            if col["name"] in categorical_cols:
+                samples = [str(v) for v in col.get("samples", []) if v]
+                if samples:
+                    all_values[col["name"]] = samples
+
+        if not all_values:
+            return []
+
+        # Build VALUES clause for SPARQL
+        flat_values = list({v for vals in all_values.values() for v in vals})
+        values_clause = " ".join(f'"{v}"' for v in flat_values)
+
+        logger.debug(
+            "Looking up DefinedTerms for %d categorical columns (%d unique values)",
+            len(all_values),
+            len(flat_values),
+        )
+
+        rows = self._sparql_query(self._DEFINED_TERM_QUERY.format(values=values_clause))
+
+        if not rows:
+            logger.debug("No matching DefinedTerms found")
+            return []
+
+        # Group results: termSet → {name → term_uri}
+        term_set_data: dict[str, dict[str, str]] = {}
+        for row in rows:
+            term_set = row.get("termSet", "")
+            term_uri = row.get("term", "")
+            name = row.get("name", "")
+            if term_set and term_uri and name:
+                term_set_data.setdefault(term_set, {})[name] = term_uri
+
+        # For each column, find the best-matching DefinedTermSet
+        matched: list[MatchedDefinedTermSet] = []
+        for col_name, samples in all_values.items():
+            best = self._best_match_for_column(col_name, samples, term_set_data)
+            if best:
+                matched.append(best)
+
+        logger.debug("Found %d DefinedTermSet matches", len(matched))
+        return matched
+
+    def _get_categorical_columns(
+        self,
+        csv_schema: dict,
+        mapping_proposal: dict | None,
+    ) -> set[str]:
+        """Return the set of column names that are categorical dimensions.
+
+        If a mapping proposal is available, only columns declared as categorical
+        dimensions are returned. Otherwise falls back to string-typed columns.
+        """
+        if mapping_proposal:
+            return {
+                d["column"]
+                for d in mapping_proposal.get("dimensions", [])
+                if d.get("type") == "categorical"
+            }
+        # Fallback: treat string-typed columns as potentially categorical
+        return {
+            col["name"]
+            for col in csv_schema.get("columns", [])
+            if col.get("type") in ("string", "categorical")
+        }
+
+    def _best_match_for_column(
+        self,
+        col_name: str,
+        samples: list[str],
+        term_set_data: dict[str, dict[str, str]],
+    ) -> MatchedDefinedTermSet | None:
+        """Find the DefinedTermSet with the highest coverage for the given column samples.
+
+        Returns None if no DefinedTermSet reaches MIN_COVERAGE or if no consistent
+        URI template can be derived (URI suffix does not match the schema:name value).
+        """
+        best: MatchedDefinedTermSet | None = None
+        best_coverage = 0.0
+
+        for term_set_uri, name_to_uri in term_set_data.items():
+            matched_values = [v for v in samples if v in name_to_uri]
+            coverage = len(matched_values) / len(samples) if samples else 0.0
+
+            if coverage < MIN_COVERAGE:
+                continue
+
+            # Check that URI suffixes match the schema:name values (exact suffix match)
+            template = self._detect_uri_template(col_name, matched_values, name_to_uri)
+            if template is None:
+                logger.debug(
+                    "DefinedTermSet <%s> has good coverage for '%s' "
+                    "but URI suffixes do not match values — skipping",
+                    term_set_uri,
+                    col_name,
+                )
+                continue
+
+            if coverage > best_coverage:
+                best_coverage = coverage
+                best = MatchedDefinedTermSet(
+                    term_set_uri=term_set_uri,
+                    uri_template=template,
+                    matched_column=col_name,
+                    coverage=coverage,
+                    sample_matches=matched_values,
+                )
+
+        return best
+
+    def _detect_uri_template(
+        self,
+        col_name: str,
+        matched_values: list[str],
+        name_to_uri: dict[str, str],
+    ) -> str | None:
+        """Detect a YARRRML URI template from matched DefinedTerm URIs.
+
+        Checks that every matched value ``v`` satisfies:
+            uri.endswith(v)
+
+        If so, extracts the common prefix and returns the template
+        ``{prefix}$(col_name)~iri``.  Returns None if the pattern does not hold.
+        """
+        if not matched_values:
+            return None
+
+        prefixes: set[str] = set()
+        for v in matched_values:
+            uri = name_to_uri.get(v, "")
+            if not uri.endswith(v):
+                return None
+            prefix = uri[: -len(v)]
+            prefixes.add(prefix)
+
+        if len(prefixes) != 1:
+            # Inconsistent prefixes across values
+            return None
+
+        prefix = next(iter(prefixes))
+        return f"{prefix}$({col_name})~iri"

--- a/src/ogd_to_lod/rml/generator.py
+++ b/src/ogd_to_lod/rml/generator.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from ogd_to_lod.ai import AIService
+from ogd_to_lod.lookup import ReuseContext
 from ogd_to_lod.logging import get_logger
 from ogd_to_lod.rml.prompts import RML_CORRECTION_PROMPT, RML_GENERATION_PROMPT
 
@@ -41,6 +42,7 @@ class RMLGenerator:
         csv_path: str,
         base_uri: str,
         dataset_context: dict[str, Any] | None = None,
+        reuse_context: ReuseContext | None = None,
     ) -> str:
         """Generate YARRRML mapping from approved proposal.
 
@@ -50,6 +52,7 @@ class RMLGenerator:
             csv_path: Path to the CSV file.
             base_uri: Base URI for generated resources.
             dataset_context: Optional normalized dataset context with column descriptions.
+            reuse_context: Optional SPARQL-based reuse context with existing URIs.
 
         Returns:
             Generated YARRRML mapping.
@@ -64,6 +67,16 @@ class RMLGenerator:
         schema_text = self._format_schema(csv_schema)
         column_desc_text = self._format_column_descriptions(dataset_context)
 
+        # Format reuse context (empty string when no matches)
+        reuse_text = ""
+        if reuse_context and reuse_context.has_matches():
+            reuse_text = "\n" + reuse_context.to_prompt_text() + "\n"
+            logger.info(
+                "Injecting reuse context: %d properties, %d DefinedTermSets",
+                len(reuse_context.properties),
+                len(reuse_context.defined_term_sets),
+            )
+
         # Build the prompt — use a placeholder for the CSV path so that the
         # generated YARRRML is portable and can be deployed with different CSV sources.
         prompt = RML_GENERATION_PROMPT.format(
@@ -71,6 +84,7 @@ class RMLGenerator:
             mapping_proposal=proposal_text,
             csv_schema=schema_text,
             column_descriptions=column_desc_text,
+            reuse_context=reuse_text,
         )
 
         logger.debug("Sending YARRRML generation prompt to AI")
@@ -251,6 +265,7 @@ def generate_rml(
     csv_schema: dict[str, Any],
     csv_path: str,
     base_uri: str,
+    reuse_context: ReuseContext | None = None,
 ) -> str:
     """Convenience function to generate YARRRML mapping.
 
@@ -260,6 +275,7 @@ def generate_rml(
         csv_schema: The CSV schema dictionary with column info.
         csv_path: Path to the CSV file.
         base_uri: Base URI for generated resources.
+        reuse_context: Optional SPARQL-based reuse context with existing URIs.
 
     Returns:
         Generated YARRRML mapping.
@@ -268,4 +284,4 @@ def generate_rml(
         RMLGenerationError: If generation fails.
     """
     generator = RMLGenerator(ai_service)
-    return generator.generate(mapping_proposal, csv_schema, csv_path, base_uri)
+    return generator.generate(mapping_proposal, csv_schema, csv_path, base_uri, reuse_context)

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -99,7 +99,7 @@ mappings:
 
 ## Column Descriptions (from dataset context)
 {column_descriptions}
-
+{reuse_context}
 ## RDF Data Cube Conventions (CRITICAL)
 
 Each CSV row represents ONE cube:Observation. Each column is either:
@@ -108,13 +108,20 @@ Each CSV row represents ONE cube:Observation. Each column is either:
 
 ### URI Conventions (MUST FOLLOW)
 
-**Properties** (dimensions and measures) — all use `ex-property:` prefix:
-- Time dimensions: ALWAYS use `ex-property:ZEIT`
-- Spatial dimensions: ALWAYS use `ex-property:RAUM`
-- Other dimensions/measures: `ex-property:` + a **sanitized** form of the column name
+**Properties** (dimensions and measures):
+- If an existing URI is listed for a column in the "Existing Vocabulary" section above, \
+use that full URI as a string literal in the predicate position (not a prefixed name).
+- Otherwise use `ex-property:` prefix:
+  - Time dimensions: ALWAYS use `ex-property:ZEIT`
+  - Spatial dimensions: ALWAYS use `ex-property:RAUM`
+  - Other dimensions/measures: `ex-property:` + a **sanitized** form of the column name
 
-**Code values** (key dimension instances) — all use `ex-code:` prefix:
-- Construct from CSV column values: `ex-code:$(columnValue)`
+**Code values** (key dimension instances):
+- If an existing URI template is listed for a column in the "Existing Vocabulary" section \
+above, use that template (it already includes the `~iri` suffix).
+- Otherwise construct from CSV column values using `ex-code:` prefix: `ex-code:$(columnValue)~iri`
+- When reusing an existing URI template, do NOT generate a separate mapping entry for \
+schema:DefinedTerm resources for that column — the DefinedTerms already exist.
 
 ### IRI-Safe Property Names (CRITICAL)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -245,7 +245,7 @@ class TestAnalyzeNode:
 
         result = analyze_node(state, mock_config)
 
-        assert result.current_state == FlowState.PROPOSE
+        assert result.current_state == FlowState.LOOKUP
         assert result.csv_schema is not None
         assert len(result.csv_schema["columns"]) == 2
         assert result.parsed_summary is not None

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,0 +1,277 @@
+"""Tests for SPARQL-based vocabulary reuse lookup."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ogd_to_lod.lookup import ReuseContext, SPARQLLookup
+from ogd_to_lod.lookup.reuse_context import MatchedDefinedTermSet, MatchedProperty
+from ogd_to_lod.lookup.sparql_client import MIN_COVERAGE
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CSV_SCHEMA = {
+    "columns": [
+        {"name": "JAHR", "type": "integer", "samples": ["2020", "2021", "2022"]},
+        {"name": "QUARTIER", "type": "string", "samples": ["Kreis 1", "Kreis 2", "Kreis 3"]},
+        {"name": "ANZAHL", "type": "decimal", "samples": ["100", "200", "300"]},
+    ]
+}
+
+SAMPLE_MAPPING_PROPOSAL = {
+    "dimensions": [
+        {"column": "JAHR", "type": "temporal"},
+        {"column": "QUARTIER", "type": "categorical"},
+    ],
+    "measures": [
+        {"column": "ANZAHL", "unit": None},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# ReuseContext
+# ---------------------------------------------------------------------------
+
+class TestReuseContext:
+    def test_empty_has_no_matches(self):
+        ctx = ReuseContext()
+        assert not ctx.has_matches()
+
+    def test_with_property_has_matches(self):
+        ctx = ReuseContext(
+            properties=[
+                MatchedProperty(
+                    existing_uri="https://example.org/property/ZEIT",
+                    label="Zeit",
+                    matched_column="JAHR",
+                )
+            ]
+        )
+        assert ctx.has_matches()
+
+    def test_with_defined_term_set_has_matches(self):
+        ctx = ReuseContext(
+            defined_term_sets=[
+                MatchedDefinedTermSet(
+                    term_set_uri="https://example.org/code/quartier/",
+                    uri_template="https://example.org/code/$(QUARTIER)~iri",
+                    matched_column="QUARTIER",
+                    coverage=1.0,
+                )
+            ]
+        )
+        assert ctx.has_matches()
+
+    def test_to_prompt_text_empty(self):
+        assert ReuseContext().to_prompt_text() == ""
+
+    def test_to_prompt_text_with_property(self):
+        ctx = ReuseContext(
+            properties=[
+                MatchedProperty(
+                    existing_uri="https://example.org/property/ZEIT",
+                    label="Zeit",
+                    matched_column="JAHR",
+                )
+            ]
+        )
+        text = ctx.to_prompt_text()
+        assert "https://example.org/property/ZEIT" in text
+        assert "JAHR" in text
+        assert "Properties" in text
+
+    def test_to_prompt_text_with_defined_term_set(self):
+        ctx = ReuseContext(
+            defined_term_sets=[
+                MatchedDefinedTermSet(
+                    term_set_uri="https://example.org/code/quartier/",
+                    uri_template="https://example.org/code/$(QUARTIER)~iri",
+                    matched_column="QUARTIER",
+                    coverage=0.75,
+                )
+            ]
+        )
+        text = ctx.to_prompt_text()
+        assert "https://example.org/code/$(QUARTIER)~iri" in text
+        assert "QUARTIER" in text
+        assert "DefinedTermSets" in text
+        assert "75%" in text
+
+    def test_to_prompt_text_instructs_no_separate_mapping(self):
+        ctx = ReuseContext(
+            defined_term_sets=[
+                MatchedDefinedTermSet(
+                    term_set_uri="https://example.org/ts",
+                    uri_template="https://example.org/code/$(COL)~iri",
+                    matched_column="COL",
+                    coverage=1.0,
+                )
+            ]
+        )
+        assert "Do NOT generate a separate mapping" in ctx.to_prompt_text()
+
+    def test_to_display_text_empty(self):
+        assert ReuseContext().to_display_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# SPARQLLookup — property lookup
+# ---------------------------------------------------------------------------
+
+PROPERTY_ROWS = [
+    {"property": "https://example.org/property/ZEIT", "label": "JAHR"},
+    {"property": "https://example.org/property/RAUM", "label": "quartier"},
+    {"property": "https://example.org/property/unrelated", "label": "something_else"},
+]
+
+
+class TestSPARQLLookupProperties:
+    def _make_lookup(self, rows):
+        lookup = SPARQLLookup("https://sparql.example.org/query")
+        lookup._sparql_query = MagicMock(return_value=rows)
+        return lookup
+
+    def test_exact_label_match(self):
+        lookup = self._make_lookup(PROPERTY_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA)
+        # "JAHR" matches label "JAHR" (case-insensitive)
+        prop_cols = {p.matched_column for p in context.properties}
+        assert "JAHR" in prop_cols
+
+    def test_matched_uri_is_correct(self):
+        lookup = self._make_lookup(PROPERTY_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA)
+        jahr_match = next(p for p in context.properties if p.matched_column == "JAHR")
+        assert jahr_match.existing_uri == "https://example.org/property/ZEIT"
+
+    def test_no_match_for_unrelated_column(self):
+        lookup = self._make_lookup(PROPERTY_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA)
+        matched_cols = {p.matched_column for p in context.properties}
+        assert "ANZAHL" not in matched_cols
+
+    def test_empty_endpoint_result_returns_empty(self):
+        lookup = self._make_lookup([])
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA)
+        assert context.properties == []
+
+    def test_sparql_error_is_logged_not_raised(self):
+        lookup = SPARQLLookup("https://sparql.example.org/query")
+        lookup._sparql_query = MagicMock(side_effect=Exception("connection refused"))
+        # Should not raise — returns empty context
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA)
+        assert context.properties == []
+
+
+# ---------------------------------------------------------------------------
+# SPARQLLookup — DefinedTermSet lookup
+# ---------------------------------------------------------------------------
+
+DEFINED_TERM_ROWS = [
+    {
+        "termSet": "https://example.org/ts/quartier",
+        "term": "https://example.org/code/Kreis 1",
+        "name": "Kreis 1",
+    },
+    {
+        "termSet": "https://example.org/ts/quartier",
+        "term": "https://example.org/code/Kreis 2",
+        "name": "Kreis 2",
+    },
+    {
+        "termSet": "https://example.org/ts/quartier",
+        "term": "https://example.org/code/Kreis 3",
+        "name": "Kreis 3",
+    },
+]
+
+
+class TestSPARQLLookupDefinedTermSets:
+    def _make_lookup(self, rows):
+        lookup = SPARQLLookup("https://sparql.example.org/query")
+        lookup._sparql_query = MagicMock(return_value=rows)
+        return lookup
+
+    def test_full_coverage_match(self):
+        lookup = self._make_lookup(DEFINED_TERM_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        dts_cols = {d.matched_column for d in context.defined_term_sets}
+        assert "QUARTIER" in dts_cols
+
+    def test_uri_template_detected(self):
+        lookup = self._make_lookup(DEFINED_TERM_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        quartier = next(d for d in context.defined_term_sets if d.matched_column == "QUARTIER")
+        assert quartier.uri_template == "https://example.org/code/$(QUARTIER)~iri"
+
+    def test_coverage_value(self):
+        lookup = self._make_lookup(DEFINED_TERM_ROWS)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        quartier = next(d for d in context.defined_term_sets if d.matched_column == "QUARTIER")
+        assert quartier.coverage == pytest.approx(1.0)
+
+    def test_below_min_coverage_not_matched(self):
+        # Only one of three values matches → coverage = 1/3 < MIN_COVERAGE
+        partial_rows = [DEFINED_TERM_ROWS[0]]
+        lookup = self._make_lookup(partial_rows)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        assert context.defined_term_sets == []
+
+    def test_no_result_returns_empty(self):
+        lookup = self._make_lookup([])
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        assert context.defined_term_sets == []
+
+    def test_uri_suffix_mismatch_skipped(self):
+        # URI does NOT end with the schema:name value → no template derivable
+        rows = [
+            {
+                "termSet": "https://example.org/ts/quartier",
+                "term": "https://example.org/code/Q1",  # suffix Q1 ≠ "Kreis 1"
+                "name": "Kreis 1",
+            },
+            {
+                "termSet": "https://example.org/ts/quartier",
+                "term": "https://example.org/code/Q2",
+                "name": "Kreis 2",
+            },
+            {
+                "termSet": "https://example.org/ts/quartier",
+                "term": "https://example.org/code/Q3",
+                "name": "Kreis 3",
+            },
+        ]
+        lookup = self._make_lookup(rows)
+        context = lookup.build_reuse_context(SAMPLE_CSV_SCHEMA, SAMPLE_MAPPING_PROPOSAL)
+        assert context.defined_term_sets == []
+
+
+# ---------------------------------------------------------------------------
+# SPARQLLookup — no endpoint (passthrough)
+# ---------------------------------------------------------------------------
+
+class TestSPARQLLookupNoEndpoint:
+    def test_no_endpoint_skipped_in_lookup_node(self):
+        """lookup_node skips SPARQL when no endpoint is configured."""
+        from ogd_to_lod.config import Config, AzureOpenAIConfig, GitHubConfig, SPARQLConfig
+        from ogd_to_lod.graph.nodes import lookup_node
+        from ogd_to_lod.graph.state import FlowState, GraphState
+
+        config = Config(
+            github=GitHubConfig(repo="org/repo", token="tok"),
+            azure=AzureOpenAIConfig(endpoint="https://e", api_key="k", deployment="d"),
+            sparql=SPARQLConfig(endpoint=None),
+        )
+        state = GraphState(
+            csv_schema=SAMPLE_CSV_SCHEMA,
+        )
+        result = lookup_node(state, config)
+
+        assert result.current_state == FlowState.PROPOSE
+        assert result.reuse_context is not None
+        assert not result.reuse_context.has_matches()
+        assert not result.awaiting_user_input


### PR DESCRIPTION
## Summary

- Adds a new **LOOKUP phase** between ANALYZE and PROPOSE that queries the configured SPARQL endpoint for existing vocabulary to reuse
- **Properties**: finds cube.link properties already used on `cube:Observation` subjects, matches them to CSV columns by `rdfs:label`
- **DefinedTerms**: finds `schema:DefinedTerm` instances whose `schema:name` values cover the CSV sample values for categorical columns; derives a URI template for direct use in YARRRML
- When matches are found, user is asked to confirm reuse or generate fresh `ex-property:`/`ex-code:` URIs
- Silent pass-through when no SPARQL endpoint is configured

## Changes

- New module `src/ogd_to_lod/lookup/` (`ReuseContext`, `SPARQLLookup`, `MatchedProperty`, `MatchedDefinedTermSet`)
- `FlowState.LOOKUP` added; `GraphState.reuse_context` field added
- `nodes.py`: new `lookup_node()`, `reuse_context` passed to `generate_node`
- `flow.py`: LOOKUP wired into graph; `_handle_lookup_confirmation()` for user yes/no
- `rml/prompts.py`: `{reuse_context}` section added to generation prompt
- `rml/generator.py`: accepts optional `reuse_context` parameter
- `CLAUDE.md`: simplified workflow (removed worktree section)
- 20 new tests in `tests/test_lookup.py`; 371 total passing

## Test plan

- [ ] Run `pytest` — all 371 tests pass
- [ ] Test with no SPARQL endpoint: flow runs unchanged (LOOKUP is silent)
- [ ] Test with SPARQL endpoint returning matches: user is asked to confirm reuse
- [ ] Verify `reuse_context.to_prompt_text()` is injected into RML generation prompt

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)