### PR TITLE
fix: harden Tier 2 Docker validation temp file handling

### DIFF
--- a/src/ogd_to_lod/validation/validator.py
+++ b/src/ogd_to_lod/validation/validator.py
@@ -171,6 +171,7 @@ class RMLValidator:
 
         try:
             yarrrml_file = Path(tmpdir.name) / "mapping.yarrrml.yaml"
+            mapping_ttl_file = Path(tmpdir.name) / "mapping.ttl"
             output_file = Path(tmpdir.name) / "output.ttl"
 
             # Replace the CSV source placeholder with the container-absolute path.
@@ -186,6 +187,21 @@ class RMLValidator:
                 parser_result = self._run_yarrrml_parser_docker(tmpdir.name, timeout)
                 if not parser_result.valid:
                     return parser_result
+                if not mapping_ttl_file.exists():
+                    return ValidationResult(
+                        valid=False,
+                        error_message=(
+                            "yarrrml-parser did not produce mapping.ttl. "
+                            "This often means the input mapping file path is not visible "
+                            "to the Docker daemon (bind mount mismatch)."
+                        ),
+                        error_category="file_not_found",
+                        user_friendly_error=(
+                            "The intermediate Turtle mapping could not be generated. "
+                            "Ensure the temporary working directory is mounted from a "
+                            "host-visible path (for Docker-in-Docker sibling containers)."
+                        ),
+                    )
 
                 # Step 2: RMLMapper executes Turtle RML against sample CSV
                 result = self._run_rmlmapper_docker(
@@ -275,7 +291,21 @@ class RMLValidator:
             TemporaryDirectory containing the sample CSV. Caller must manage
             its lifecycle (cleanup).
         """
-        tmpdir = tempfile.TemporaryDirectory()
+        tmpdir_base = os.environ.get("TMPDIR")
+        tempdir_kwargs: dict[str, str] = {}
+        if tmpdir_base:
+            tmpdir_path = Path(tmpdir_base)
+            try:
+                tmpdir_path.mkdir(parents=True, exist_ok=True)
+                tempdir_kwargs["dir"] = str(tmpdir_path)
+            except OSError as e:
+                logger.warning(
+                    "TMPDIR '%s' is unusable (%s), falling back to system temp dir",
+                    tmpdir_base,
+                    e,
+                )
+
+        tmpdir = tempfile.TemporaryDirectory(**tempdir_kwargs)
 
         try:
             source_path = Path(csv_path)
@@ -541,6 +571,20 @@ class RMLValidator:
                 user_friendly_error=(
                     "The YARRRML mapping could not be parsed. "
                     "Check the YAML syntax and YARRRML structure."
+                ),
+            )
+
+        # yarrrml-parser may return zero even when input is missing.
+        parser_output = f"{result.stdout}\n{result.stderr}".lower()
+        if "input file" in parser_output and "not found" in parser_output:
+            error_msg = (result.stderr or result.stdout).strip()
+            return ValidationResult(
+                valid=False,
+                error_message=error_msg,
+                error_category="file_not_found",
+                user_friendly_error=(
+                    "yarrrml-parser could not access the input YARRRML file. "
+                    "This is usually a Docker bind-mount path visibility issue."
                 ),
             )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -432,6 +432,23 @@ class TestYARRRMLParserDocker:
         cmd = mock_run.call_args[0][0]
         assert custom_image in cmd
 
+    @patch("subprocess.run")
+    def test_yarrrml_parser_missing_input_detected_even_with_zero_exit(self, mock_run):
+        """Parser sometimes returns 0 even when input file is missing."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="The input file /data/mapping.yarrrml.yaml is not found.",
+        )
+
+        validator = RMLValidator(use_docker=True)
+        result = validator._run_yarrrml_parser_docker("/tmp/testdir", timeout=30)
+
+        assert result.valid is False
+        assert result.error_category == "file_not_found"
+        assert "not found" in (result.error_message or "").lower()
+
 
 class TestIsEmptyRDFOutput:
     """Tests for _is_empty_rdf_output static helper."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -359,6 +359,14 @@ class TestValidateWithRMLMapper:
     @patch("subprocess.run")
     def test_rmlmapper_failure(self, mock_run, data_csv, sample_rml):
         """Test that RMLMapper failure (step 2) returns invalid result."""
+        _path_exists = Path.exists
+
+        def path_exists(self: Path) -> bool:
+            # yarrrml-parser is mocked; pretend it wrote mapping.ttl
+            if self.name == "mapping.ttl":
+                return True
+            return _path_exists(self)
+
         mock_run.side_effect = [
             # Step 1: yarrrml-parser succeeds
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
@@ -372,7 +380,8 @@ class TestValidateWithRMLMapper:
         ]
 
         validator = RMLValidator(use_docker=True)
-        result = validator.validate_with_rmlmapper(sample_rml, data_csv)
+        with patch.object(Path, "exists", path_exists):
+            result = validator.validate_with_rmlmapper(sample_rml, data_csv)
 
         assert result.valid is False
         assert result.error_category == "missing_column"


### PR DESCRIPTION
## Summary

- Detect yarrrml-parser missing-input failures even on zero exit code
- Ensure temporary validation files are created in a Docker-visible TMPDIR path
- Enhance `test_rmlmapper_failure` to mock `Path.exists` for failure scenarios

Supersedes the earlier attempt in #52 (closed without merge).

## Test plan

- [x] `pytest tests/test_validation.py`


Made with [Cursor](https://cursor.com)