### PR TITLE
feat: Huwise mapping push automation (CI + e2e scripts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4.1
 # Overrides the value in config.yaml (default: redlink-gmbh/ogd-to-lod-mappings)
 # GITHUB_REPO=redlink-gmbh/ogd-to-lod-mappings
 
+# Optional: Huwise domain (required when using --dataset-id)
+# Example: data.bs.ch
+# The CLI derives: https://<HUWISE_DOMAIN>/api/explore/v2.1
+# HUWISE_DOMAIN=data.bs.ch
+# HUWISE_API_KEY=your-automation-api-key-here
+# Used by tests/e2e/push-to-huwise.sh (Automation API, not Explore)
+
 # Optional: Log level for debugging and tracing
 # Supported levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # DEBUG - Detailed information for diagnosing problems
@@ -19,3 +26,13 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4.1
 # WARNING - Something unexpected happened
 # ERROR - Serious problem occurred
 LOG_LEVEL=INFO
+
+# Base URI for generated RDF resources (required)
+# Substituted into config.yaml as rml.base_uri. Used in YARRRML prefixes (ex:,
+# ex-property:, etc.) and in metadata.ttl cube / observation IRIs.
+# Must be an absolute IRI: include the scheme (https://) and a trailing slash.
+# Wrong: ld.bs.ch   Right: https://ld.bs.ch/
+# With --output-folder <slug>, dataset-specific IRIs are under <base><slug>/...
+# If you use docker compose --profile trifid, keep this aligned with Trifid's
+# DATASET_BASE_URL so resource URLs dereference correctly.
+DATASET_BASE_URL=https://ld.bs.ch/

--- a/.github/workflows/push-huwise-mapping.yml
+++ b/.github/workflows/push-huwise-mapping.yml
@@ -1,0 +1,86 @@
+# Push mapping.yarrrml.yaml to Huwise after it lands on main (mappings repo layout).
+#
+# Secrets required: HUWISE_DOMAIN, HUWISE_API_KEY
+#
+# Manual run: Actions → Push YARRRML to Huwise → Run workflow
+# Auto run: push to main under mapping/**/mapping.yarrrml.yaml
+
+name: Push YARRRML to Huwise
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset_id:
+        description: Huwise dataset_id (e.g. 100051)
+        required: true
+        type: string
+      mapping_folder:
+        description: Folder containing mapping.yarrrml.yaml (e.g. mapping/weather-binningen-hourly)
+        required: true
+        type: string
+      dry_run:
+        description: Dry run (no PUT/POST)
+        required: false
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - "mapping/**/mapping.yarrrml.yaml"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve mapping folder (push event)
+        if: github.event_name == 'push'
+        id: detect
+        run: |
+          mapfile -t files < <(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" \
+            | grep -E '^mapping/.+/mapping\.yarrrml\.yaml$' || true)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No mapping.yarrrml.yaml changes detected; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          folder="$(dirname "${files[0]}")"
+          echo "folder=${folder}" >> "$GITHUB_OUTPUT"
+          echo "Detected mapping folder: ${folder}"
+
+      - name: Push to Huwise (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+        env:
+          HUWISE_DOMAIN: ${{ secrets.HUWISE_DOMAIN }}
+          HUWISE_API_KEY: ${{ secrets.HUWISE_API_KEY }}
+        run: |
+          scripts/push-yarrrml-after-merge.sh \
+            --dataset-id "${{ inputs.dataset_id }}" \
+            "${{ inputs.mapping_folder }}"
+
+      - name: Dry run (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+        env:
+          HUWISE_DOMAIN: ${{ secrets.HUWISE_DOMAIN }}
+          HUWISE_API_KEY: ${{ secrets.HUWISE_API_KEY }}
+        run: |
+          scripts/push-yarrrml-after-merge.sh --dry-run \
+            --dataset-id "${{ inputs.dataset_id }}" \
+            "${{ inputs.mapping_folder }}"
+
+      - name: Push to Huwise (push to main)
+        if: github.event_name == 'push' && steps.detect.outputs.skip != 'true'
+        env:
+          HUWISE_DOMAIN: ${{ secrets.HUWISE_DOMAIN }}
+          HUWISE_API_KEY: ${{ secrets.HUWISE_API_KEY }}
+          HUWISE_DATASET_ID: ${{ vars.HUWISE_DATASET_ID }}
+        run: |
+          if [[ -z "${HUWISE_DATASET_ID:-}" ]]; then
+            echo "Set repository variable HUWISE_DATASET_ID for automatic push on main," >&2
+            echo "or run this workflow manually with workflow_dispatch." >&2
+            exit 1
+          fi
+          scripts/push-yarrrml-after-merge.sh \
+            --dataset-id "${HUWISE_DATASET_ID}" \
+            "${{ steps.detect.outputs.folder }}"

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -1,19 +1,21 @@
 # Hackathon Quickstart
 
-Get from a fresh clone to "observations queryable in Fuseki" in about ten
-minutes, using Docker for everything.
+Get from a fresh clone to **live RDF on Huwise** or **observations in local
+Fuseki** in about ten minutes. Mapping generation runs in Docker; Huwise push
+runs on your machine (see prerequisites).
 
 ## What you'll do
 
-1. Bring up the `ogd-to-lod` container and a local Apache Jena Fuseki.
-2. Generate a YARRRML mapping + static metadata for a bundled example CSV
-   (Basel-Binningen air-quality, hourly).
-3. Materialise the mapping into Turtle (`observations.ttl`) with
-   yarrrml-parser + RMLMapper.
-4. Load the observations and metadata into Fuseki and explore them.
+1. Bring up the `ogd-to-lod` container (and optionally Fuseki).
+2. Generate a YARRRML mapping + static metadata (bundled CSV example, or
+   `--dataset-id` from Huwise).
+3. **Huwise path** — push the mapping to the portal so RDF/TPF works on the
+   live dataset (do this right after step 2 when using `--dataset-id`).
+4. **Local path (optional)** — materialise Turtle with yarrrml-parser +
+   RMLMapper and load into Fuseki for SPARQL on your laptop.
 
-All artifacts land in `results/<timestamp>-weather-binningen-hourly/` on
-the host — open the folder in your IDE while the commands are running.
+All artifacts land in `results/<timestamp>-<slug>/` on the host — open the
+folder in your IDE while the commands are running.
 
 ## Prerequisites
 
@@ -23,11 +25,18 @@ the host — open the folder in your IDE while the commands are running.
   - `AZURE_OPENAI_KEY`
   - `AZURE_OPENAI_DEPLOYMENT`
   - `APP_GITHUB_TOKEN` — any value; only used by the PR path, not by `--local`.
-- That's it. No local Python install, no Java, no node.
+- For dataset bootstrap mode (`--dataset-id`) and Huwise push, also set:
+  - `HUWISE_DOMAIN` (for example `data.bs.ch`)
+  - `HUWISE_API_KEY` — Automation API key with edit rights on the dataset
+- **Host tools for Huwise push only** (mapping generation still uses Docker):
+  - `python3`, `curl`, and PyYAML (`pip install pyyaml` or `pip install -e .`
+    from the repo root)
+- No local Java or Node required for the default flow.
 
 ```bash
 cp .env.example .env
 # edit .env with your credentials
+pip install -e .   # optional but recommended if push-to-huwise fails on "import yaml"
 ```
 
 ## Step 1 — Build the image and start Fuseki
@@ -42,9 +51,16 @@ Fuseki is now serving an empty dataset `test` at
 
 ## Step 2 — Generate the mapping with `--local`
 
-The example folder `example/weather-binningen-hourly/` contains a small
-CSV plus a DCAT description and a column glossary. Run the full pipeline
-against it:
+Preferred path: run with dataset bootstrap (`--dataset-id`) so CSV and
+metadata are fetched automatically:
+
+```bash
+docker compose run --rm ogd-to-lod \
+    --dataset-id 100051 \
+    --local
+```
+
+Alternative path: run against the local bundled files:
 
 ```bash
 docker compose run --rm ogd-to-lod \
@@ -54,6 +70,10 @@ docker compose run --rm ogd-to-lod \
               example/weather-binningen-hourly/fields.txt \
     --local
 ```
+
+In dataset mode, setup artifacts are materialized under
+`.work/dataset_setup/<timestamp>-100051/` and then fed into the same
+workflow.
 
 The tool is interactive — it will:
 
@@ -67,22 +87,64 @@ Note: the first run may take a while, as it needs to download the `yarrrml-parse
 When it finishes, you'll have a new folder under `results/`:
 
 ```
-results/<YYYYMMDD-HHMMSS>-weather-binningen-hourly/
+results/<YYYYMMDD-HHMMSS>-<slug>/
 ├── data.csv
 ├── mapping.yarrrml.yaml
 ├── metadata.ttl
 └── PR.md
 ```
 
-Pick that folder's path; you'll reuse it in the next two steps. For
-brevity below, set:
+Pick that folder's path; you'll reuse it below. For brevity:
 
 ```bash
-RESULT=$(ls -dt results/*-weather-binningen-hourly | head -1)
+# Latest results folder (adjust the glob if you used --dataset-id 100051)
+RESULT=$(ls -dt results/* | head -1)
 echo "$RESULT"
 ```
 
-## Step 3 — Materialise RDF (`observations.ttl`)
+## Two paths after Step 2
+
+| Goal | Next step |
+|------|-----------|
+| **RDF on Huwise** (live portal / TPF) | [Step 3 — Push to Huwise](#step-3--push-to-huwise-dataset-id) |
+| **RDF on your laptop** (Fuseki) | [Step 4 — Materialise](#step-4--materialise-rdf-observationsttl) then Step 5 |
+
+When you used `--dataset-id`, do **Step 3 first** — Huwise does not use
+`{CSV_SOURCE}` or local `data.csv`; the push script converts ogd-to-lod
+YARRRML into the [Huwise mapping dialect](https://help.opendatasoft.com/apis/tpf)
+(no `sources:`, full IRIs, `predicateobjects:`, `$(technical_field_name)`).
+
+## Step 3 — Push to Huwise (`--dataset-id`)
+
+Requires `HUWISE_DOMAIN` and `HUWISE_API_KEY` in `.env`.
+
+```bash
+tests/e2e/push-to-huwise.sh --check   # optional: verify semantic/rml_mapping field
+tests/e2e/push-to-huwise.sh --dataset-id 100051 "$RESULT"
+```
+
+Dry-run (resolve uid + show URLs, no writes):
+
+```bash
+tests/e2e/push-to-huwise.sh --dry-run --dataset-id 100051 "$RESULT"
+```
+
+This uses the [Automation API](https://developer.huwise.com/apis/automation/v1.0/index.html)
+(`PUT .../metadata/semantic/rml_mapping/` then `POST .../publish_metadata/`).
+The script prepares the mapping (drops `{CSV_SOURCE}` / `sources:`, rewrites
+labels → technical field names, expands prefixes to full IRIs). Use `--raw`
+only for debugging.
+
+After a successful push, the script checks the [TPF API](https://help.opendatasoft.com/apis/tpf).
+You can also open:
+
+`https://<HUWISE_DOMAIN>/api/tpf/<DATASET_ID>/`
+
+Example: `https://data.bs.ch/api/tpf/100051/` — look for observation IRIs and
+literal measures (`o3_ug_m3`, etc.). Full `exports/turtle` can be very large
+and slow to download; prefer TPF for a quick check.
+
+## Step 4 — Materialise RDF (`observations.ttl`)
 
 The helper script substitutes the `{CSV_SOURCE}` placeholder, runs
 yarrrml-parser to convert YARRRML → RML, then RMLMapper to execute the
@@ -97,7 +159,7 @@ ls "$RESULT/observations.ttl"
 (The script uses sibling Docker containers — it'll pull
 `rmlio/yarrrml-parser` and `rmlio/rmlmapper-java` the first time.)
 
-## Step 4 — Load everything into Fuseki
+## Step 5 — Load everything into Fuseki
 
 ```bash
 tests/e2e/post-to-fuseki.sh --clean "$RESULT"
@@ -108,7 +170,7 @@ state. `metadata.ttl` (the static cube + per-property descriptions) and
 `observations.ttl` (the per-row triples) are uploaded via Fuseki's Graph
 Store Protocol.
 
-## Step 5 — Explore
+## Step 6 — Explore
 
 Open the Fuseki UI: <http://localhost:3030/#/dataset/test/query>.
 
@@ -143,7 +205,7 @@ PREFIX cube: <https://cube.link/>
 SELECT ?p ?o WHERE { ?obs a cube:Observation ; ?p ?o } LIMIT 50
 ```
 
-## Step 6 — Browse the RDF in a Linked-Data viewer (optional)
+## Step 7 — Browse the RDF in a Linked-Data viewer (optional)
 
 Fuseki's SPARQL UI is fine for queries; for click-through *browsing* of
 each cube / observation / property as an HTML page, bring up **Trifid**:
@@ -164,7 +226,7 @@ preconfigured with:
 
 ### Dereferencing your cube IRIs
 
-The bundled example uses `https://ld.domain.ch/statistics/...` as the
+The bundled example uses `https://ld.bs.ch/...` as the
 base. Trifid's `DATASET_BASE_URL` is set to that host by default in
 `docker-compose.yml`, so a request to
 
@@ -173,7 +235,7 @@ http://localhost:8080/statistics/weather-binningen-hourly
 ```
 
 is rewritten to a SPARQL `DESCRIBE` against
-`<https://ld.domain.ch/statistics/weather-binningen-hourly>` and you get
+`<https://ld.bs.ch/weather-binningen-hourly>` and you get
 the cube's full set of triples rendered as HTML. Same trick for any
 observation, property, or DefinedTerm IRI.
 
@@ -190,7 +252,7 @@ If you just want to inspect a specific resource without running Trifid,
 Fuseki's SPARQL UI handles `DESCRIBE` natively:
 
 ```sparql
-DESCRIBE <https://ld.domain.ch/statistics/weather-binningen-hourly>
+DESCRIBE <https://ld.bs.ch/weather-binningen-hourly>
 ```
 
 That returns the same triple set Trifid renders, just without the HTML
@@ -198,12 +260,10 @@ chrome.
 
 ## Iterating
 
-- Edit `mapping.yarrrml.yaml` by hand in the result folder, then re-run
-  Step 3 and Step 4 to see the changes in Fuseki.
-- `--clean` on `post-to-fuseki.sh` resets the dataset between iterations.
-- To start over with a different CSV, drop one into a sub-folder under
-  `example/` (or anywhere in the repo) and re-run Step 2 with the new
-  paths and `--output-folder`.
+- **Huwise:** edit `mapping.yarrrml.yaml`, then re-run Step 3 (`push-to-huwise.sh`).
+- **Fuseki:** edit the mapping, then re-run Step 4 and Step 5.
+- `--clean` on `post-to-fuseki.sh` resets the local dataset between iterations.
+- To start over with a different CSV or dataset id, re-run Step 2.
 
 ## Tearing down
 Stops Fuseki + Trifid (if running) and drops Fuseki's data volume
@@ -216,6 +276,11 @@ you want to start from a clean tree.
 
 ## When something goes wrong
 
+- `import yaml` / PyYAML error when pushing to Huwise — install host deps:
+  `pip install -e .` from the repo root.
+- Push succeeds but TPF has no observations — ensure `--dataset-id` matches
+  the portal dataset and field refs use Huwise technical names (`datum_zeit`,
+  not `Datum/Zeit`); re-push without `--raw`.
 - `[Errno 2] No such file or directory: 'docker'` inside the container —
   the image is stale; rebuild with `docker compose build --no-cache`.
 - Fuseki refuses uploads with `403 Forbidden` — credentials drifted from

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The application uses a YAML configuration file (`config/config.yaml`) with envir
 |----------|-------------|---------|
 | `GITHUB_REPO` | Target repository for generated mappings | `redlink-gmbh/ogd-to-lod-mappings` |
 | `LOG_LEVEL` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
+| `HUWISE_DOMAIN` | Huwise domain used to derive `https://<domain>/api/explore/v2.1` (required only with `--dataset-id`) | unset |
+| `HUWISE_API_KEY` | Huwise Automation API key for [`tests/e2e/push-to-huwise.sh`](tests/e2e/push-to-huwise.sh) | unset |
 
 ### Configuration File
 
@@ -136,6 +138,11 @@ docker compose run --rm ogd-to-lod \
     --context example/weather-binningen-hourly/dcat.ttl \
               example/weather-binningen-hourly/fields.txt \
     --local
+
+# One-shot run with dataset bootstrap (downloads CSV + metadata first):
+docker compose run --rm ogd-to-lod \
+    --dataset-id 100051 \
+    --local
 ```
 
 Credentials come from `.env` (same variables as the native install).
@@ -144,14 +151,17 @@ Credentials come from `.env` (same variables as the native install).
 
 ```bash
 ogd-to-lod <csv_path> --output-folder <folder> [--context FILE ...]
+# or
+ogd-to-lod --dataset-id <id> [--output-folder <folder>]
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `csv_path` | Path to the CSV file to map (required) |
-| `--output-folder FOLDER` | Target subfolder name in the mappings directory (required). The CSV and YARRRML files are pushed to `{mappings_folder}/{output-folder}/` in the repository. |
+| `csv_path` | Path to the CSV file to map (required for file-path mode) |
+| `--dataset-id ID` | Dataset identifier for bootstrap mode. The CLI downloads CSV + metadata from Huwise before running the normal workflow. |
+| `--output-folder FOLDER` | Target subfolder name in the mappings directory. Required for file-path mode; defaults to `--dataset-id` in dataset mode. |
 | `--context FILE [FILE ...]` | One or more context files describing the dataset. Any format is accepted: DCAT (JSON-LD, Turtle, RDF/XML), Markdown, plain text, JSON, or combinations thereof. |
 
 ### Options
@@ -161,6 +171,7 @@ ogd-to-lod <csv_path> --output-folder <folder> [--context FILE ...]
 | `--config` | `-c` | Path to configuration file (default: `config/config.yaml`) |
 | `--base-uri` | `-b` | Base URI for generated resources (overrides config) |
 | `--local` | | Write results to `results/<timestamp>-<output-folder>/` instead of opening a GitHub PR |
+| `--dataset-id` | | Bootstrap CSV/context from Huwise API using dataset id |
 | `--help` | | Show help message |
 
 ### Examples
@@ -195,7 +206,27 @@ ogd-to-lod example/weather-binningen-hourly/data.csv \
     --context example/weather-binningen-hourly/dcat.ttl \
     --base-uri https://example.org/data/ \
     --local
+
+# Dataset bootstrap mode (requires HUWISE_DOMAIN)
+ogd-to-lod --dataset-id 100051 --local
 ```
+
+### Dataset Bootstrap Mode (`--dataset-id`)
+
+When `--dataset-id` is used, the CLI derives the base URL (derived_base_url) as:
+
+- `https://<HUWISE_DOMAIN>/api/explore/v2.1`
+
+Then it runs a setup phase before the mapping flow:
+
+- fetches dataset metadata JSON from `<derived_base_url>/catalog/datasets/{id}`
+- fetches CSV export from `<derived_base_url>/catalog/datasets/{id}/exports/csv`
+- fetches DCAT Turtle from `<derived_base_url>/catalog/exports/ttl?where=dataset_id="{id}"`
+- generates a `fields.json` context file from the dataset `fields` schema
+
+Setup artifacts are written under `.work/dataset_setup/<timestamp>-<dataset-id>/` and then passed into the existing pipeline as local inputs.
+
+If `--dataset-id` is set and `HUWISE_DOMAIN` is missing, the CLI aborts with an explicit error.
 
 The resulting PR will contain two files in `{mappings_folder}/{output-folder}/`:
 
@@ -305,6 +336,33 @@ tests/e2e/post-to-fuseki.sh --clean results/<YYYYMMDD-HHMMSS>-<output-folder>
 Protocol with HTTP basic auth; override `FUSEKI_URL` /
 `FUSEKI_UPDATE_URL` / `FUSEKI_USER` / `FUSEKI_PASSWORD` to point at a
 different endpoint.
+
+### Push YARRRML to Huwise (Automation API)
+
+After `--local` (or from a merged `mapping/<folder>/mapping.yarrrml.yaml`), push
+the mapping into Huwise `semantic.rml_mapping` metadata:
+
+```bash
+# Verify semantic template + rml_mapping field on your portal
+tests/e2e/push-to-huwise.sh --check
+
+# From a results folder (HACKATHON.md Step 3)
+tests/e2e/push-to-huwise.sh --dataset-id 100051 results/<timestamp>-<output-folder>
+
+# From mappings-repo layout after merge
+scripts/push-yarrrml-after-merge.sh --dataset-id 100051 mapping/<output-folder>
+```
+
+Requires `HUWISE_DOMAIN` and `HUWISE_API_KEY` in `.env`, plus host `python3`
+with PyYAML (`pip install -e .`). Prepares ogd-to-lod YARRRML for the
+[Huwise TPF mapping dialect](https://help.opendatasoft.com/apis/tpf), then uses
+[Automation API](https://developer.huwise.com/apis/automation/v1.0/index.html)
+(`PUT .../metadata/semantic/rml_mapping/` then `POST .../publish_metadata/`).
+Verifies RDF via `https://<HUWISE_DOMAIN>/api/tpf/<DATASET_ID>/` after publish.
+
+Optional: GitHub Actions workflow [`.github/workflows/push-huwise-mapping.yml`](.github/workflows/push-huwise-mapping.yml)
+(manual `workflow_dispatch`, or push to `main` under `mapping/**/mapping.yarrrml.yaml`
+with repo variable `HUWISE_DATASET_ID` and secrets `HUWISE_DOMAIN`, `HUWISE_API_KEY`).
 
 ## Project Structure
 

--- a/scripts/push-yarrrml-after-merge.sh
+++ b/scripts/push-yarrrml-after-merge.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Push mapping.yarrrml.yaml from a mappings-repository folder layout to Huwise.
+#
+# Use after a mapping PR is merged to main (mapping/<output-folder>/mapping.yarrrml.yaml).
+# Delegates to tests/e2e/push-to-huwise.sh.
+#
+# Usage:
+#   scripts/push-yarrrml-after-merge.sh [--dry-run] --dataset-id ID <mapping-folder>
+#
+# Example:
+#   scripts/push-yarrrml-after-merge.sh --dataset-id 100051 mapping/weather-binningen-hourly
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PUSH="$REPO_ROOT/tests/e2e/push-to-huwise.sh"
+
+DRY_RUN=()
+DATASET_ID=""
+FOLDER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=(--dry-run)
+      shift
+      ;;
+    --dataset-id)
+      DATASET_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$FOLDER" ]]; then
+        echo "Error: unexpected extra argument: $1" >&2
+        exit 1
+      fi
+      FOLDER="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$DATASET_ID" ]]; then
+  echo "Error: --dataset-id is required" >&2
+  exit 1
+fi
+if [[ -z "$FOLDER" ]]; then
+  sed -n '2,12p' "$0" >&2
+  exit 1
+fi
+
+MAPPING_FILE="$FOLDER/mapping.yarrrml.yaml"
+if [[ ! -f "$MAPPING_FILE" ]]; then
+  echo "Error: expected $MAPPING_FILE" >&2
+  exit 1
+fi
+
+exec "$PUSH" "${DRY_RUN[@]}" --dataset-id "$DATASET_ID" --mapping-file "$MAPPING_FILE"

--- a/tests/e2e/prepare_mapping_for_huwise.py
+++ b/tests/e2e/prepare_mapping_for_huwise.py
@@ -13,6 +13,7 @@ Huwise (TPF / RDF exports) expects:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 import urllib.request

--- a/tests/e2e/prepare_mapping_for_huwise.py
+++ b/tests/e2e/prepare_mapping_for_huwise.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Transform ogd-to-lod YARRRML into Huwise-native mapping dialect.
+
+Huwise (TPF / RDF exports) expects:
+  - Only a ``mappings:`` block (no ``sources:``, no ``{CSV_SOURCE}``, no ``prefixes:``)
+  - ``subject:`` / ``predicateobjects:`` (RMLio ``s`` / ``po`` are optional shortcuts but
+    we emit Huwise-style keys for compatibility)
+  - Full IRIs for predicates, classes, and datatypes (not ``ex-property:`` / ``xsd:``)
+  - Inter-resource links as mapping *keys* (not ``~iri`` strings)
+  - ``$(field_name)`` uses Huwise technical field ``name`` values
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_FIELD_REF_RE = re.compile(r"\$\(([^)]+)\)")
+
+_XSD_IRIS = {
+    "dateTime": "http://www.w3.org/2001/XMLSchema#dateTime",
+    "decimal": "http://www.w3.org/2001/XMLSchema#decimal",
+    "string": "http://www.w3.org/2001/XMLSchema#string",
+    "gYear": "http://www.w3.org/2001/XMLSchema#gYear",
+    "integer": "http://www.w3.org/2001/XMLSchema#integer",
+    "double": "http://www.w3.org/2001/XMLSchema#double",
+    "boolean": "http://www.w3.org/2001/XMLSchema#boolean",
+}
+
+
+def _fetch_field_map(domain: str, dataset_id: str) -> dict[str, str]:
+    url = f"https://{domain}/api/explore/v2.1/catalog/datasets/{dataset_id}"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    mapping: dict[str, str] = {}
+    for field in payload.get("fields") or []:
+        if not isinstance(field, dict):
+            continue
+        name = field.get("name")
+        if not name:
+            continue
+        mapping[name] = name
+        label = field.get("label")
+        if label and label != name:
+            mapping[label] = name
+    return mapping
+
+
+def _rewrite_field_references(text: str, field_map: dict[str, str]) -> tuple[str, list[str]]:
+    unknown: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        target = field_map.get(key)
+        if target is None:
+            unknown.append(key)
+            return match.group(0)
+        return f"$({target})"
+
+    return _FIELD_REF_RE.sub(replace, text), unknown
+
+
+def _strip_quotes(value: str) -> str:
+    value = value.strip()
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _expand_curie(value: str, prefixes: dict[str, str]) -> str:
+    if value == "a":
+        return "a"
+    cleaned = _strip_quotes(value)
+    if cleaned.endswith("~iri"):
+        cleaned = cleaned[:-4]
+    if cleaned.startswith("http://") or cleaned.startswith("https://"):
+        return cleaned
+    if ":" not in cleaned:
+        return cleaned
+    prefix, local = cleaned.split(":", 1)
+    base = prefixes.get(prefix)
+    if base:
+        return f"{base.rstrip('/')}/{local.lstrip('/')}" if local else base.rstrip("/")
+    return cleaned
+
+
+def _expand_template(value: str, prefixes: dict[str, str]) -> str:
+    text = _strip_quotes(value)
+    if "$(" in text:
+        head, tail = text.split("$(", 1)
+        head = head.rstrip("/")
+        if ":" in head:
+            prefix_key, local = head.split(":", 1)
+            base = prefixes.get(prefix_key)
+            if base:
+                base = base.rstrip("/")
+                local = local.lstrip("/")
+                head_expanded = f"{base}/{local}" if local else base
+            else:
+                head_expanded = _expand_curie(head, prefixes)
+        else:
+            head_expanded = _expand_curie(head, prefixes) if head else head
+        if not head_expanded:
+            return f"$({tail}"
+        if tail.startswith("/"):
+            return f"{head_expanded}$({tail}"
+        return f"{head_expanded}/$({tail}"
+    return _expand_curie(text, prefixes)
+
+
+def _resolve_link_object(
+    obj: Any,
+    prefixes: dict[str, str],
+    mapping_keys: dict[str, dict[str, Any]],
+) -> Any:
+    if not isinstance(obj, str):
+        return obj
+    raw = _strip_quotes(obj)
+    if raw.endswith("~iri"):
+        raw = raw[:-4]
+    expanded = _expand_template(raw, prefixes)
+    for key, entry in mapping_keys.items():
+        subject = entry.get("s") or entry.get("subject") or ""
+        subject_str = _strip_quotes(str(subject))
+        subject_expanded = _expand_template(subject_str, prefixes)
+        if "$(" in subject_expanded and "$(" in expanded:
+            if subject_expanded.split("$(")[0] == expanded.split("$(")[0]:
+                return key
+        elif subject_expanded == expanded:
+            return key
+    return expanded
+
+
+def _convert_predicate_object(
+    row: list[Any],
+    prefixes: dict[str, str],
+    mapping_keys: dict[str, dict[str, Any]],
+) -> list[Any]:
+    if not row:
+        return row
+    out: list[Any] = list(row)
+    if isinstance(out[0], str):
+        pred = _expand_curie(out[0], prefixes)
+        out[0] = "a" if pred.endswith("#type") or pred == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" else pred
+        if out[0] != "a" and not str(out[0]).startswith(("http://", "https://")):
+            out[0] = _expand_curie(str(out[0]), prefixes)
+    if len(out) > 1:
+        if isinstance(out[1], str):
+            raw_obj = _strip_quotes(str(out[1]))
+            if raw_obj.startswith("$("):
+                out[1] = raw_obj
+            else:
+                out[1] = _resolve_link_object(out[1], prefixes, mapping_keys)
+                if isinstance(out[1], str) and not out[1].startswith(
+                    ("http://", "https://", "$(")
+                ):
+                    out[1] = _expand_curie(str(out[1]), prefixes)
+        elif isinstance(out[1], list):
+            pass
+    if len(out) > 2 and isinstance(out[2], str):
+        dtype = _strip_quotes(out[2])
+        if dtype.startswith("xsd:"):
+            out[2] = _XSD_IRIS.get(dtype[4:], dtype)
+        elif dtype.endswith("~lang"):
+            out[2] = dtype
+        elif not dtype.startswith("http"):
+            out[2] = _XSD_IRIS.get(dtype, dtype)
+    return out
+
+
+def _convert_to_huwise_dialect(doc: dict[str, Any]) -> dict[str, Any]:
+    prefixes: dict[str, str] = dict(doc.get("prefixes") or {})
+    raw_mappings: dict[str, Any] = dict(doc.get("mappings") or {})
+    huwise_mappings: dict[str, Any] = {}
+
+    for key, entry in raw_mappings.items():
+        if not isinstance(entry, dict):
+            continue
+        huwise_mappings[key] = dict(entry)
+
+    for key, entry in huwise_mappings.items():
+        entry.pop("sources", None)
+        if "s" in entry:
+            entry["subject"] = _expand_template(str(entry.pop("s")), prefixes)
+        elif "subject" in entry:
+            entry["subject"] = _expand_template(str(entry["subject"]), prefixes)
+
+        po = entry.pop("po", None) or entry.pop("predicateobjects", None)
+        if po is not None:
+            converted: list[Any] = []
+            for row in po:
+                if isinstance(row, list):
+                    converted.append(
+                        _convert_predicate_object(row, prefixes, huwise_mappings)
+                    )
+                else:
+                    converted.append(row)
+            entry["predicateobjects"] = converted
+
+    return {"mappings": huwise_mappings}
+
+
+def prepare_mapping(
+    yarrrml: str,
+    *,
+    domain: str,
+    dataset_id: str | None,
+    field_map: dict[str, str] | None = None,
+) -> tuple[str, list[str]]:
+    if field_map is None and dataset_id:
+        field_map = _fetch_field_map(domain, dataset_id)
+    text, unknown = _rewrite_field_references(yarrrml, field_map or {})
+
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict):
+        raise ValueError("YARRRML root must be a mapping object")
+
+    doc.pop("sources", None)
+    huwise_doc = _convert_to_huwise_dialect(doc)
+    output = yaml.dump(
+        huwise_doc,
+        Dumper=_HuwiseDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    return output, sorted(set(unknown))
+
+
+class _HuwiseDumper(yaml.SafeDumper):
+    """Dump predicate-object rows as inline [a, b, c] lists."""
+
+
+def _represent_str(dumper: yaml.Dumper, data: str) -> Any:
+    # Bare $(field) in flow-style lists is parsed as a YAML alias.
+    if "$(" in data or data.startswith("/"):
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+def _represent_list(dumper: yaml.Dumper, data: list[Any]) -> Any:
+    if data and all(isinstance(item, (str, int, float, bool)) or item is None for item in data):
+        return dumper.represent_sequence(
+            "tag:yaml.org,2002:seq", data, flow_style=True
+        )
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", data)
+
+
+_HuwiseDumper.add_representer(str, _represent_str)
+_HuwiseDumper.add_representer(list, _represent_list)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mapping_file", type=Path)
+    parser.add_argument("--domain", required=True, help="Huwise domain, e.g. data.bs.ch")
+    parser.add_argument("--dataset-id", help="Dataset id for field name lookup")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write prepared mapping here (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    yarrrml = args.mapping_file.read_text(encoding="utf-8")
+    domain = args.domain.rstrip("/").removeprefix("https://").removeprefix("http://")
+
+    prepared, unknown = prepare_mapping(
+        yarrrml,
+        domain=domain,
+        dataset_id=args.dataset_id,
+    )
+
+    if unknown:
+        print(
+            f"Warning: unmapped field references: {', '.join(unknown)}",
+            file=sys.stderr,
+        )
+
+    if args.output:
+        args.output.write_text(prepared, encoding="utf-8")
+    else:
+        sys.stdout.write(prepared)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/push-to-huwise.sh
+++ b/tests/e2e/push-to-huwise.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Push YARRRML to Huwise semantic.rml_mapping via the Automation API.
+#
+# Usage:
+#   tests/e2e/push-to-huwise.sh [--dry-run] [--check] (--dataset-id ID | --dataset-uid UID)
+#       (<results-folder> | --mapping-file PATH)
+#
+# Optional semantic fields (if files exist or paths given):
+#   [--classes-file PATH] [--properties-file PATH]
+#
+# By default the mapping is transformed for Huwise (drops sources/{CSV_SOURCE},
+# rewrites $(label) → $(technical_field_name)). Pass --raw to push the file as-is.
+#
+# Environment (or repo-root .env):
+#   HUWISE_DOMAIN   e.g. data.bs.ch
+#   HUWISE_API_KEY  Automation API key with dataset edit rights
+#
+# Examples:
+#   tests/e2e/push-to-huwise.sh --check
+#   tests/e2e/push-to-huwise.sh --dataset-id 100051 results/<timestamp>-weather-binningen-hourly
+#   tests/e2e/push-to-huwise.sh --dataset-uid da_wn1p7t --mapping-file mapping/slug/mapping.yarrrml.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+load_env() {
+  if [[ -f "$REPO_ROOT/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$REPO_ROOT/.env"
+    set +a
+  fi
+}
+
+usage() {
+  sed -n '2,18p' "$0"
+}
+
+normalize_domain() {
+  local d="${1%/}"
+  d="${d#https://}"
+  d="${d#http://}"
+  echo "$d"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+json_value_payload() {
+  local file="$1"
+  python3 -c 'import json, sys; print(json.dumps({"value": open(sys.argv[1], encoding="utf-8").read()}))' "$file"
+}
+
+json_null_payload() {
+  python3 -c 'import json; print(json.dumps({"value": None}))'
+}
+
+resolve_dataset_uid() {
+  local domain="$1"
+  local dataset_id="$2"
+  local explore_url="https://${domain}/api/explore/v2.1/catalog/datasets/${dataset_id}"
+  local body
+  body="$(curl --silent --show-error --fail "$explore_url")"
+  python3 -c 'import json, sys; d=json.load(sys.stdin); print(d["dataset_uid"])' <<<"$body"
+}
+
+resolve_dataset_id() {
+  local automation_base="$1"
+  local auth_header="$2"
+  local dataset_uid="$3"
+  local url="${automation_base}/datasets/${dataset_uid}/"
+  local body
+  body="$(curl --silent --show-error --fail -H "$auth_header" "$url")"
+  python3 -c 'import json, sys; d=json.load(sys.stdin); print(d["dataset_id"])' <<<"$body"
+}
+
+verify_tpf_rdf() {
+  local domain="$1"
+  local dataset_id="$2"
+  local url="https://${domain}/api/tpf/${dataset_id}/"
+  echo "→ Verify RDF via TPF ${url}"
+  local sample
+  sample="$(curl --silent --show-error --max-time 20 "$url" 2>/dev/null | head -c 8192 || true)"
+  if echo "$sample" | grep -qE '/observation/|Observation'; then
+    echo "  ✓ TPF returns RDF triples"
+    return 0
+  fi
+  echo "  ✗ TPF sample has no observations — check semantic.rml_mapping" >&2
+  return 1
+}
+
+prepare_mapping_for_huwise() {
+  local mapping_file="$1"
+  local domain="$2"
+  local dataset_id="$3"
+  local output_file="$4"
+  if ! python3 -c 'import yaml' 2>/dev/null; then
+    echo "Error: PyYAML required on the host for mapping preparation." >&2
+    echo "  pip install pyyaml   # or: pip install -e ." >&2
+    exit 1
+  fi
+  echo "→ Prepare mapping for Huwise (drop sources/CSV_SOURCE, use field names)"
+  python3 "${SCRIPT_DIR}/prepare_mapping_for_huwise.py" \
+    "$mapping_file" \
+    --domain "$domain" \
+    --dataset-id "$dataset_id" \
+    -o "$output_file"
+}
+
+check_semantic_template() {
+  local automation_base="$1"
+  local auth_header="$2"
+  local url="${automation_base}/metadata/templates/semantic/fields/"
+  echo "→ GET semantic template fields → ${url}"
+  local body
+  body="$(curl --silent --show-error --fail -H "$auth_header" "$url")"
+  HUWISE_CHECK_BODY="$body" python3 -c '
+import json
+import os
+
+fields = json.loads(os.environ["HUWISE_CHECK_BODY"])
+if isinstance(fields, list):
+    items = fields
+elif isinstance(fields, dict) and "results" in fields:
+    items = fields["results"]
+else:
+    items = list(fields.values()) if isinstance(fields, dict) else [fields]
+names = []
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    name = item.get("name") or item.get("field_name")
+    if not name:
+        continue
+    names.append(name)
+    if name == "rml_mapping":
+        print(
+            "  rml_mapping: type=%s, requirement=%s"
+            % (item.get("type", "?"), item.get("requirement_level", "?"))
+        )
+if "rml_mapping" not in names:
+    print("  WARNING: rml_mapping field not listed — semantic template may be inactive")
+else:
+    print("  OK: semantic template exposes rml_mapping")
+'
+}
+
+put_metadata_field() {
+  local dry_run="$1"
+  local auth_header="$2"
+  local url="$3"
+  local payload="$4"
+  local label="$5"
+  local bytes
+  bytes="$(printf '%s' "$payload" | wc -c | tr -d ' ')"
+  echo "→ PUT ${label} (${bytes} bytes JSON) → ${url}"
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "  (dry-run: skipped)"
+    return 0
+  fi
+  curl --silent --show-error --fail \
+    -X PUT \
+    -H "$auth_header" \
+    -H "Content-Type: application/json" \
+    --data-binary "$payload" \
+    "$url"
+  echo "  ✓ ${label} updated"
+}
+
+DRY_RUN=0
+CHECK_ONLY=0
+RAW_UPLOAD=0
+DATASET_ID=""
+DATASET_UID=""
+FOLDER=""
+MAPPING_FILE=""
+CLASSES_FILE=""
+PROPERTIES_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --raw)
+      RAW_UPLOAD=1
+      shift
+      ;;
+    --check)
+      CHECK_ONLY=1
+      shift
+      ;;
+    --dataset-id)
+      DATASET_ID="${2:-}"
+      shift 2
+      ;;
+    --dataset-uid)
+      DATASET_UID="${2:-}"
+      shift 2
+      ;;
+    --mapping-file)
+      MAPPING_FILE="${2:-}"
+      shift 2
+      ;;
+    --classes-file)
+      CLASSES_FILE="${2:-}"
+      shift 2
+      ;;
+    --properties-file)
+      PROPERTIES_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$FOLDER" ]]; then
+        echo "Error: unexpected extra argument: $1" >&2
+        exit 1
+      fi
+      FOLDER="$1"
+      shift
+      ;;
+  esac
+done
+
+load_env
+require_cmd curl
+require_cmd python3
+
+HUWISE_DOMAIN="$(normalize_domain "${HUWISE_DOMAIN:-}")"
+if [[ -z "$HUWISE_DOMAIN" ]]; then
+  echo "Error: HUWISE_DOMAIN is not set (e.g. data.bs.ch)" >&2
+  exit 1
+fi
+if [[ -z "${HUWISE_API_KEY:-}" ]]; then
+  echo "Error: HUWISE_API_KEY is not set" >&2
+  exit 1
+fi
+
+AUTOMATION_BASE="https://${HUWISE_DOMAIN}/api/automation/v1.0"
+AUTH_HEADER="Authorization: ApiKey ${HUWISE_API_KEY}"
+
+if [[ $CHECK_ONLY -eq 1 ]]; then
+  check_semantic_template "$AUTOMATION_BASE" "$AUTH_HEADER"
+  exit 0
+fi
+
+if [[ -n "$MAPPING_FILE" && -n "$FOLDER" ]]; then
+  echo "Error: pass either a results folder or --mapping-file, not both" >&2
+  exit 1
+fi
+
+if [[ -n "$MAPPING_FILE" ]]; then
+  if [[ ! -f "$MAPPING_FILE" ]]; then
+    echo "Error: mapping file not found: $MAPPING_FILE" >&2
+    exit 1
+  fi
+  MAPPING="$MAPPING_FILE"
+  if [[ -z "$CLASSES_FILE" && -f "$(dirname "$MAPPING_FILE")/semantic.classes" ]]; then
+    CLASSES_FILE="$(dirname "$MAPPING_FILE")/semantic.classes"
+  fi
+  if [[ -z "$PROPERTIES_FILE" && -f "$(dirname "$MAPPING_FILE")/semantic.properties" ]]; then
+    PROPERTIES_FILE="$(dirname "$MAPPING_FILE")/semantic.properties"
+  fi
+elif [[ -n "$FOLDER" ]]; then
+  if [[ ! -d "$FOLDER" ]]; then
+    echo "Error: not a directory: $FOLDER" >&2
+    exit 1
+  fi
+  MAPPING="$FOLDER/mapping.yarrrml.yaml"
+  if [[ ! -f "$MAPPING" ]]; then
+    echo "Error: missing $MAPPING" >&2
+    exit 1
+  fi
+  if [[ -z "$CLASSES_FILE" && -f "$FOLDER/semantic.classes" ]]; then
+    CLASSES_FILE="$FOLDER/semantic.classes"
+  fi
+  if [[ -z "$PROPERTIES_FILE" && -f "$FOLDER/semantic.properties" ]]; then
+    PROPERTIES_FILE="$FOLDER/semantic.properties"
+  fi
+else
+  echo "Error: pass a results folder or --mapping-file" >&2
+  exit 1
+fi
+
+if [[ -z "$DATASET_ID" && -z "$DATASET_UID" ]]; then
+  echo "Error: pass --dataset-id or --dataset-uid" >&2
+  exit 1
+fi
+if [[ -n "$DATASET_ID" && -n "$DATASET_UID" ]]; then
+  echo "Error: use only one of --dataset-id or --dataset-uid" >&2
+  exit 1
+fi
+
+if [[ -z "$DATASET_UID" ]]; then
+  echo "→ Resolve dataset_uid for dataset_id=${DATASET_ID}"
+  DATASET_UID="$(resolve_dataset_uid "$HUWISE_DOMAIN" "$DATASET_ID")"
+  echo "  uid: ${DATASET_UID}"
+elif [[ -z "$DATASET_ID" ]]; then
+  echo "→ Resolve dataset_id for dataset_uid=${DATASET_UID}"
+  DATASET_ID="$(resolve_dataset_id "$AUTOMATION_BASE" "$AUTH_HEADER" "$DATASET_UID")"
+  echo "  id: ${DATASET_ID}"
+fi
+
+PREPARED_MAPPING=""
+cleanup_prepared() {
+  if [[ -n "$PREPARED_MAPPING" && -f "$PREPARED_MAPPING" ]]; then
+    rm -f "$PREPARED_MAPPING"
+  fi
+}
+trap cleanup_prepared EXIT
+
+if [[ $RAW_UPLOAD -eq 0 ]]; then
+  if [[ -z "$DATASET_ID" ]]; then
+    echo "Error: --dataset-id is required for Huwise mapping preparation (or use --raw)" >&2
+    exit 1
+  fi
+  PREPARED_MAPPING="$(mktemp "${TMPDIR:-/tmp}/huwise-mapping.XXXXXX")"
+  prepare_mapping_for_huwise "$MAPPING" "$HUWISE_DOMAIN" "$DATASET_ID" "$PREPARED_MAPPING"
+  MAPPING="$PREPARED_MAPPING"
+fi
+
+META_BASE="${AUTOMATION_BASE}/datasets/${DATASET_UID}/metadata/semantic"
+
+put_metadata_field "$DRY_RUN" "$AUTH_HEADER" \
+  "${META_BASE}/rml_mapping/" \
+  "$(json_value_payload "$MAPPING")" \
+  "semantic/rml_mapping"
+
+if [[ -n "$CLASSES_FILE" ]]; then
+  if [[ ! -f "$CLASSES_FILE" ]]; then
+    echo "Error: classes file not found: $CLASSES_FILE" >&2
+    exit 1
+  fi
+  put_metadata_field "$DRY_RUN" "$AUTH_HEADER" \
+    "${META_BASE}/classes/" \
+    "$(json_value_payload "$CLASSES_FILE")" \
+    "semantic/classes"
+fi
+
+if [[ -n "$PROPERTIES_FILE" ]]; then
+  if [[ ! -f "$PROPERTIES_FILE" ]]; then
+    echo "Error: properties file not found: $PROPERTIES_FILE" >&2
+    exit 1
+  fi
+  put_metadata_field "$DRY_RUN" "$AUTH_HEADER" \
+    "${META_BASE}/properties/" \
+    "$(json_value_payload "$PROPERTIES_FILE")" \
+    "semantic/properties"
+fi
+
+PUBLISH_URL="${AUTOMATION_BASE}/datasets/${DATASET_UID}/publish_metadata/"
+echo "→ POST publish_metadata → ${PUBLISH_URL}"
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "  (dry-run: skipped)"
+else
+  curl --silent --show-error --fail \
+    -X POST \
+    -H "$AUTH_HEADER" \
+    "$PUBLISH_URL"
+  echo "  ✓ metadata published"
+  verify_tpf_rdf "$HUWISE_DOMAIN" "$DATASET_ID"
+fi
+
+echo "Done. RDF (TPF): https://${HUWISE_DOMAIN}/api/tpf/${DATASET_ID}/"
+echo "  Full export may be large; prefer TPF over exports/turtle for a quick check."


### PR DESCRIPTION
## Summary

Adds end-to-end automation for pushing YARRRML mappings to Huwise after merge:

- GitHub Actions workflow (`.github/workflows/push-huwise-mapping.yml`)
- E2E scripts: `tests/e2e/prepare_mapping_for_huwise.py`, `tests/e2e/push-to-huwise.sh`
- Post-merge helper: `scripts/push-yarrrml-after-merge.sh`
- Huwise API documentation in `README.md` and `HACKATHON.md`
- `HUWISE_DOMAIN` / `HUWISE_API_KEY` in `.env.example`

## Dependencies

Best merged **after** #66 (`pr/csv-url-confirmation-flow`), which adds the `--dataset-id` workflow these scripts rely on.

## Test plan

- [ ] Run `tests/e2e/prepare_mapping_for_huwise.py` against a test dataset
- [ ] Verify workflow triggers on mapping branch merge (dry-run or staging dataset)


Made with [Cursor](https://cursor.com)