### PR TITLE
chore: align config, base URI, and fork settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,13 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4.1
 # WARNING - Something unexpected happened
 # ERROR - Serious problem occurred
 LOG_LEVEL=INFO
+
+# Base URI for generated RDF resources (required)
+# Substituted into config.yaml as rml.base_uri. Used in YARRRML prefixes (ex:,
+# ex-property:, etc.) and in metadata.ttl cube / observation IRIs.
+# Must be an absolute IRI: include the scheme (https://) and a trailing slash.
+# Wrong: ld.bs.ch   Right: https://ld.bs.ch/
+# With --output-folder <slug>, dataset-specific IRIs are under <base><slug>/...
+# If you use docker compose --profile trifid, keep this aligned with Trifid's
+# DATASET_BASE_URL so resource URLs dereference correctly.
+DATASET_BASE_URL=https://ld.bs.ch/

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -164,7 +164,7 @@ preconfigured with:
 
 ### Dereferencing your cube IRIs
 
-The bundled example uses `https://ld.domain.ch/statistics/...` as the
+The bundled example uses `https://ld.bs.ch...` as the
 base. Trifid's `DATASET_BASE_URL` is set to that host by default in
 `docker-compose.yml`, so a request to
 
@@ -173,7 +173,7 @@ http://localhost:8080/statistics/weather-binningen-hourly
 ```
 
 is rewritten to a SPARQL `DESCRIBE` against
-`<https://ld.domain.ch/statistics/weather-binningen-hourly>` and you get
+`<https://ld.bs.chweather-binningen-hourly>` and you get
 the cube's full set of triples rendered as HTML. Same trick for any
 observation, property, or DefinedTerm IRI.
 
@@ -190,7 +190,7 @@ If you just want to inspect a specific resource without running Trifid,
 Fuseki's SPARQL UI handles `DESCRIBE` natively:
 
 ```sparql
-DESCRIBE <https://ld.domain.ch/statistics/weather-binningen-hourly>
+DESCRIBE <https://ld.bs.chweather-binningen-hourly>
 ```
 
 That returns the same triple set Trifid renders, just without the HTML

--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -164,7 +164,7 @@ preconfigured with:
 
 ### Dereferencing your cube IRIs
 
-The bundled example uses `https://ld.bs.ch...` as the
+The bundled example uses `https://ld.bs.ch/...` as the
 base. Trifid's `DATASET_BASE_URL` is set to that host by default in
 `docker-compose.yml`, so a request to
 
@@ -173,7 +173,7 @@ http://localhost:8080/statistics/weather-binningen-hourly
 ```
 
 is rewritten to a SPARQL `DESCRIBE` against
-`<https://ld.bs.chweather-binningen-hourly>` and you get
+`<https://ld.bs.ch/weather-binningen-hourly>` and you get
 the cube's full set of triples rendered as HTML. Same trick for any
 observation, property, or DefinedTerm IRI.
 
@@ -190,7 +190,7 @@ If you just want to inspect a specific resource without running Trifid,
 Fuseki's SPARQL UI handles `DESCRIBE` natively:
 
 ```sparql
-DESCRIBE <https://ld.bs.chweather-binningen-hourly>
+DESCRIBE <https://ld.bs.ch/weather-binningen-hourly>
 ```
 
 That returns the same triple set Trifid renders, just without the HTML

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@
 
 github:
   # Target repository for generated mappings (can also be set via GITHUB_REPO env var)
-  repo: "redlink-gmbh/ogd-to-lod-mappings"
+  repo: "opendatabs/ogd-to-lod"
   token: "${APP_GITHUB_TOKEN}"
   # Parent folder in the repository for all mappings (default: mapping)
   # mappings_folder: "mapping"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,7 +29,7 @@ sparql:
 
 rml:
   # Base URI pattern for generated resources
-  base_uri: "https://ld.domain.ch/statistics/"
+  base_uri: "${DATASET_BASE_URL}"
   # Use Docker for two-step validation: yarrrml-parser → RMLMapper
   rmlmapper_use_docker: true
   # Docker image for RMLMapper (Tier 2 validation, step 2)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,12 +21,6 @@ azure:
     price_per_1m_output_tokens: 8.08   # CHF per 1M output tokens
     price_per_1m_cached_tokens: 0.10   # CHF per 1M cached tokens
 
-sparql:
-  # Optional SPARQL linker (EARLY STAGE / experimental): queries an endpoint for
-  # existing cube.link properties and DefinedTerms to reuse. Disabled by default —
-  # uncomment and set an endpoint to enable. With no endpoint the lookup is skipped.
-  # endpoint: "http://localhost:3030/test/query"
-
 rml:
   # Base URI pattern for generated resources
   base_uri: "${DATASET_BASE_URL}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - "8080:8080"
     environment:
       - SPARQL_ENDPOINT_URL=http://fuseki:3030/test/query
-      - DATASET_BASE_URL=${DATASET_BASE_URL:-https://ld.domain.ch}
+      - DATASET_BASE_URL=${DATASET_BASE_URL:-https://ld.bs.ch}
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
   #
   # DATASET_BASE_URL must match the host prefix of the IRIs you want to
   # dereference. The default below matches the example dataset shipped
-  # with this repo (https://ld.bs.ch<slug>/...). Change
+  # with this repo (https://ld.bs.ch/<slug>/...). Change
   # it to whatever your generated cube IRIs use.
   trifid:
     image: zazuko/trifid:latest
@@ -86,7 +86,7 @@ services:
       - "8080:8080"
     environment:
       - SPARQL_ENDPOINT_URL=http://fuseki:3030/test/query
-      - DATASET_BASE_URL=${DATASET_BASE_URL:-https://ld.bs.ch}
+      - DATASET_BASE_URL=${DATASET_BASE_URL:-https://ld.bs.ch/}
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
   #
   # DATASET_BASE_URL must match the host prefix of the IRIs you want to
   # dereference. The default below matches the example dataset shipped
-  # with this repo (https://ld.domain.ch/statistics/<slug>/...). Change
+  # with this repo (https://ld.bs.ch<slug>/...). Change
   # it to whatever your generated cube IRIs use.
   trifid:
     image: zazuko/trifid:latest

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -211,13 +211,13 @@ string + `~iri`, no angle brackets):
 
 ```yaml
 # WRONG — angle-bracket IRI in object position:
-- [cube:observation, <https://ld.bs.chobservation/2024_CH>]
+- [cube:observation, <https://ld.bs.ch/observation/2024_CH>]
 
 # CORRECT — prefixed CURIE + ~iri (the prefix is declared in prefixes:):
 - [cube:observation, "ex-obs:2024_CH~iri"]
 
 # Also correct — full IRI as a string + ~iri (no angle brackets):
-- [cube:observation, "https://ld.bs.chobservation/2024_CH~iri"]
+- [cube:observation, "https://ld.bs.ch/observation/2024_CH~iri"]
 ```
 
 **CRITICAL — Constant IRI subjects MUST be CURIEs**: Angle-bracket IRIs \
@@ -230,11 +230,11 @@ that resolves via a declared prefix instead.
 ```yaml
 # WRONG — bare angle-bracket IRI on an s: line:
   observationSetLink:
-    s: <https://ld.bs.chobservation-set>
+    s: <https://ld.bs.ch/observation-set>
 
 # WRONG — quoted angle-bracket IRI on an s: line:
   observationSetLink:
-    s: "<https://ld.bs.chobservation-set>"
+    s: "<https://ld.bs.ch/observation-set>"
 
 # CORRECT — CURIE using a declared prefix (ex: is in prefixes:):
   observationSetLink:
@@ -327,7 +327,7 @@ the brackets. Use a CURIE (declared in `prefixes:`) instead.
 In **object** position, append `~iri` to the CURIE:
 ```yaml
 # Wrong — bare angle-bracket IRI in object position:
-- [cube:observation, <https://ld.bs.chobservation/2024_CH>]
+- [cube:observation, <https://ld.bs.ch/observation/2024_CH>]
 # Correct — prefixed CURIE + ~iri:
 - [cube:observation, "ex-obs:2024_CH~iri"]
 ```
@@ -337,10 +337,10 @@ no `~iri` suffix:
 ```yaml
 # Wrong — bare angle-bracket IRI on s: line:
   observationSetLink:
-    s: <https://ld.bs.chobservation-set>
+    s: <https://ld.bs.ch/observation-set>
 # Wrong — quoted angle-bracket IRI on s: line:
   observationSetLink:
-    s: "<https://ld.bs.chobservation-set>"
+    s: "<https://ld.bs.ch/observation-set>"
 # Correct — CURIE using a declared prefix:
   observationSetLink:
     s: ex:observation-set

--- a/src/ogd_to_lod/rml/prompts.py
+++ b/src/ogd_to_lod/rml/prompts.py
@@ -211,13 +211,13 @@ string + `~iri`, no angle brackets):
 
 ```yaml
 # WRONG — angle-bracket IRI in object position:
-- [cube:observation, <https://ld.domain.ch/statistics/observation/2024_CH>]
+- [cube:observation, <https://ld.bs.chobservation/2024_CH>]
 
 # CORRECT — prefixed CURIE + ~iri (the prefix is declared in prefixes:):
 - [cube:observation, "ex-obs:2024_CH~iri"]
 
 # Also correct — full IRI as a string + ~iri (no angle brackets):
-- [cube:observation, "https://ld.domain.ch/statistics/observation/2024_CH~iri"]
+- [cube:observation, "https://ld.bs.chobservation/2024_CH~iri"]
 ```
 
 **CRITICAL — Constant IRI subjects MUST be CURIEs**: Angle-bracket IRIs \
@@ -230,11 +230,11 @@ that resolves via a declared prefix instead.
 ```yaml
 # WRONG — bare angle-bracket IRI on an s: line:
   observationSetLink:
-    s: <https://ld.domain.ch/statistics/observation-set>
+    s: <https://ld.bs.chobservation-set>
 
 # WRONG — quoted angle-bracket IRI on an s: line:
   observationSetLink:
-    s: "<https://ld.domain.ch/statistics/observation-set>"
+    s: "<https://ld.bs.chobservation-set>"
 
 # CORRECT — CURIE using a declared prefix (ex: is in prefixes:):
   observationSetLink:
@@ -327,7 +327,7 @@ the brackets. Use a CURIE (declared in `prefixes:`) instead.
 In **object** position, append `~iri` to the CURIE:
 ```yaml
 # Wrong — bare angle-bracket IRI in object position:
-- [cube:observation, <https://ld.domain.ch/statistics/observation/2024_CH>]
+- [cube:observation, <https://ld.bs.chobservation/2024_CH>]
 # Correct — prefixed CURIE + ~iri:
 - [cube:observation, "ex-obs:2024_CH~iri"]
 ```
@@ -337,10 +337,10 @@ no `~iri` suffix:
 ```yaml
 # Wrong — bare angle-bracket IRI on s: line:
   observationSetLink:
-    s: <https://ld.domain.ch/statistics/observation-set>
+    s: <https://ld.bs.chobservation-set>
 # Wrong — quoted angle-bracket IRI on s: line:
   observationSetLink:
-    s: "<https://ld.domain.ch/statistics/observation-set>"
+    s: "<https://ld.bs.chobservation-set>"
 # Correct — CURIE using a declared prefix:
   observationSetLink:
     s: ex:observation-set


### PR DESCRIPTION
## Summary

Operational alignment for the opendatabs fork deployment:

- Point `config.yaml` at `opendatabs/ogd-to-lod` and remove stale SPARQL linker comments
- Align `docker-compose.yml` and `rml/prompts.py` base URI references with `https://ld.bs.ch/`
- Document `DATASET_BASE_URL` in `.env.example` for Trifid / YARRRML prefix consistency

**Contributors:** @osaeedi, @oschihin (docker-compose and config.yaml updates)

## Test plan

- [ ] Verify `config/config.yaml` loads without errors
- [ ] Confirm `DATASET_BASE_URL` in `.env.example` matches docker-compose Trifid config


Made with [Cursor](https://cursor.com)