### PR TITLE
fix: break SPARQL-lookup infinite loop

### DIFF
--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -108,8 +108,6 @@ class MappingFlow:
             },
         )
 
-        graph.add_edge("wait_for_lookup", "lookup")
-
         graph.add_edge("propose", "wait_for_input")
 
         graph.add_conditional_edges(


### PR DESCRIPTION
## Summary

Removes the `wait_for_lookup → lookup` edge in the LangGraph flow that caused an infinite loop when waiting for vocabulary reuse confirmation.

**Author:** @schenkerrolf (SchenkerRolf)

## Context

This fix should merge **before** #66 (`pr/csv-url-confirmation-flow`), which was branched before this fix landed on `opendatabs/main` and still contains the problematic edge.

## Test plan

- [ ] Confirm SPARQL linker flow terminates after lookup wait state
- [ ] `pytest` (no dedicated test; graph wiring change only)


Made with [Cursor](https://cursor.com)