### PR TITLE
feat: CSV source URL confirmation flow + dataset-id sample handling

### DIFF
--- a/src/ogd_to_lod/cli.py
+++ b/src/ogd_to_lod/cli.py
@@ -13,6 +13,14 @@ from ogd_to_lod.logging import get_logger
 logger = get_logger(__name__)
 
 
+def compose_dataset_csv_source_url(base_url: str, dataset_id: str) -> str:
+    """Compose the proposed public CSV source URL for dataset-id mode."""
+    return (
+        f"{base_url}/catalog/datasets/{dataset_id}/exports/csv"
+        "?&use_labels=true&delimiter=%2C"
+    )
+
+
 def format_token_stats(flow: MappingFlow) -> str:
     """Format token usage statistics as a string.
 
@@ -161,6 +169,7 @@ def main() -> int:
     csv_path = args.csv_path
     context_paths = args.context_paths or []
     output_folder = args.output_folder
+    proposed_csv_source_url: str | None = None
 
     if args.dataset_id:
         output_folder = output_folder or args.dataset_id
@@ -178,6 +187,7 @@ def main() -> int:
             normalized_domain = normalized_domain[len("http://"):]
         normalized_domain = normalized_domain.strip("/")
         base_url = f"https://{normalized_domain}/api/explore/v2.1"
+        proposed_csv_source_url = compose_dataset_csv_source_url(base_url, args.dataset_id)
         try:
             setup = prepare_dataset_inputs(dataset_id=args.dataset_id, base_url=base_url)
         except DatasetSetupError as e:
@@ -213,6 +223,7 @@ def main() -> int:
             base_uri=args.base_uri,
             output_folder=output_folder,
             local_output=args.local,
+            proposed_csv_source_url=proposed_csv_source_url,
         )
     except Exception as e:
         logger.exception("Failed to start mapping flow")
@@ -243,6 +254,12 @@ def main() -> int:
         if flow.is_awaiting_name_confirmation():
             name = flow.state.mapping_name or "mapping"
             prompt = f"Dataset name ['{name}']: "
+        elif flow.is_awaiting_proposed_csv_url_confirmation():
+            proposed_url = flow.get_proposed_csv_source_url() or ""
+            print("Proposed public CSV source URL:")
+            print(proposed_url)
+            print("")
+            prompt = "Use this public CSV source URL? (yes/no): "
         elif flow.is_awaiting_csv_url():
             prompt = "Public CSV source URL (Enter to skip): "
         elif flow.is_awaiting_pr_confirmation():
@@ -266,6 +283,7 @@ def main() -> int:
         # Allow empty input for name confirmation and URL states (Enter = skip)
         allows_empty = (
             flow.is_awaiting_name_confirmation()
+            or flow.is_awaiting_proposed_csv_url_confirmation()
             or flow.is_awaiting_csv_url()
         )
         if not user_input and not allows_empty:

--- a/src/ogd_to_lod/github/service.py
+++ b/src/ogd_to_lod/github/service.py
@@ -82,18 +82,17 @@ class GitHubService:
     ) -> PRResult:
         """Create a PR with a new RML mapping.
 
-        Creates a new branch, commits the YARRRML mapping file, the CSV
-        source file, a ``README.md`` with the PR description (rendered from
-        ``config/pr_template.md``), and optionally static metadata, then opens
-        a pull request.
+        Creates a new branch, commits the YARRRML mapping file, a ``README.md``
+        with the PR description (rendered from ``config/pr_template.md``), and
+        optionally static metadata, then opens a pull request.
 
         Args:
             mapping_name: Name for the mapping (used in PR title and commit messages).
             rml_content: The YARRRML mapping content to commit.
             description: Human-readable description for the PR body.
             output_folder: Subfolder name within the mappings parent folder.
-            csv_filename: Filename for the CSV file in the repository.
-            csv_content: Content of the CSV file to commit.
+            csv_filename: Source CSV filename (kept for API compatibility).
+            csv_content: Source CSV content (kept for API compatibility).
             metadata_content: Optional static metadata Turtle (cube:Cube +
                 ObservationSet) to commit as ``metadata.ttl``.
             base_branch: Branch to create PR against (default: main).
@@ -110,7 +109,6 @@ class GitHubService:
         branch_name = f"mapping/{safe_folder}"
         folder_path = f"{mappings_folder}/{safe_folder}"
         yarrrml_path = f"{folder_path}/mapping.yarrrml.yaml"
-        csv_path_in_repo = f"{folder_path}/{csv_filename}"
 
         logger.info(f"Creating PR for mapping: {mapping_name}")
         logger.debug(f"Branch: {branch_name}, Folder: {folder_path}")
@@ -129,13 +127,6 @@ class GitHubService:
                 branch_name, yarrrml_path, rml_content,
                 f"Add YARRRML mapping: {mapping_name}"
             )
-
-            # Commit the CSV source file
-            self._commit_file(
-                branch_name, csv_path_in_repo, csv_content,
-                f"Add CSV source: {csv_filename}"
-            )
-            logger.debug(f"Committed CSV file: {csv_path_in_repo}")
 
             # Optionally commit the static metadata Turtle
             if metadata_content:

--- a/src/ogd_to_lod/graph/flow.py
+++ b/src/ogd_to_lod/graph/flow.py
@@ -381,6 +381,7 @@ class MappingFlow:
         base_uri: str | None = None,
         output_folder: str | None = None,
         local_output: bool = False,
+        proposed_csv_source_url: str | None = None,
     ) -> GraphState:
         """Start the mapping flow.
 
@@ -403,6 +404,7 @@ class MappingFlow:
             base_uri=base_uri,
             output_folder=output_folder,
             local_output=local_output,
+            proposed_csv_source_url=proposed_csv_source_url,
         )
 
         # Run until we need user input
@@ -433,6 +435,9 @@ class MappingFlow:
             return self._handle_name_confirmation(user_input)
 
         # Handle source URL and context inclusion states
+        if self._state.current_state == FlowState.CONFIRM_PROPOSED_CSV_URL:
+            return self._handle_proposed_csv_url_confirmation(user_input)
+
         if self._state.current_state == FlowState.ASK_CSV_URL:
             return self._handle_csv_url(user_input)
 
@@ -598,6 +603,15 @@ class MappingFlow:
         else:
             logger.info("User accepted suggested name: %s", self._state.mapping_name)
 
+        if self._state.proposed_csv_source_url:
+            self._state.current_state = FlowState.CONFIRM_PROPOSED_CSV_URL
+            self._state.awaiting_user_input = True
+            self._state.add_message(
+                "assistant",
+                "Use this public CSV source URL? (yes/no):",
+            )
+            return self._state
+
         # Transition to ASK_CSV_URL
         self._state.current_state = FlowState.ASK_CSV_URL
         self._state.awaiting_user_input = True
@@ -605,6 +619,36 @@ class MappingFlow:
             "assistant",
             "Enter the public URL for the CSV source (or press Enter to skip):",
         )
+
+        return self._state
+
+    def _handle_proposed_csv_url_confirmation(self, user_input: str) -> GraphState:
+        """Handle yes/no confirmation for proposed dataset-id CSV source URL."""
+        self._state.add_message("user", user_input)
+        answer = user_input.lower().strip()
+
+        if answer in ("yes", "y", "ok", "sure", "proceed"):
+            self._state.csv_source_url = self._state.proposed_csv_source_url
+            logger.info(
+                "User accepted proposed CSV source URL: %s",
+                self._state.proposed_csv_source_url,
+            )
+            self._state = preview_node(self._state, self._ai_service)
+        elif answer in ("no", "n", "cancel", "skip", "exit", "quit"):
+            logger.info("User declined proposed CSV source URL")
+            self._state.current_state = FlowState.ASK_CSV_URL
+            self._state.awaiting_user_input = True
+            self._state.add_message(
+                "assistant",
+                "Enter the public URL for the CSV source (or press Enter to skip):",
+            )
+        else:
+            self._state.current_state = FlowState.CONFIRM_PROPOSED_CSV_URL
+            self._state.awaiting_user_input = True
+            self._state.add_message(
+                "assistant",
+                "Please answer with 'yes' or 'no'.",
+            )
 
         return self._state
 
@@ -741,6 +785,17 @@ class MappingFlow:
             self._state.current_state == FlowState.ASK_CSV_URL
             and self._state.awaiting_user_input
         )
+
+    def is_awaiting_proposed_csv_url_confirmation(self) -> bool:
+        """Check if flow is waiting for proposed CSV URL confirmation."""
+        return (
+            self._state.current_state == FlowState.CONFIRM_PROPOSED_CSV_URL
+            and self._state.awaiting_user_input
+        )
+
+    def get_proposed_csv_source_url(self) -> str | None:
+        """Get the proposed CSV source URL for dataset-id mode."""
+        return self._state.proposed_csv_source_url
 
     def get_pr_description(self) -> str | None:
         """Get the built PR description."""

--- a/src/ogd_to_lod/graph/state.py
+++ b/src/ogd_to_lod/graph/state.py
@@ -18,6 +18,7 @@ class FlowState(Enum):
     GENERATE = "generate"
     VALIDATE = "validate"
     CONFIRM_NAME = "confirm_name"
+    CONFIRM_PROPOSED_CSV_URL = "confirm_proposed_csv_url"
     ASK_CSV_URL = "ask_csv_url"
     PREVIEW = "preview"
     CREATE_PR = "create_pr"
@@ -152,6 +153,7 @@ class GraphState:
 
     # Source URL (populated in ASK_CSV_URL state)
     csv_source_url: str | None = None
+    proposed_csv_source_url: str | None = None
 
     context_raw_files: list[dict] = field(default_factory=list)  # all context files
 
@@ -204,6 +206,7 @@ class GraphState:
             "mapping_decisions": self.mapping_decisions,
             "mapping_name": self.mapping_name,
             "csv_source_url": self.csv_source_url,
+            "proposed_csv_source_url": self.proposed_csv_source_url,
             "context_raw_files": self.context_raw_files,
             "pr_description": self.pr_description,
             "validation_error": self.validation_error,

--- a/src/ogd_to_lod/huwise_setup.py
+++ b/src/ogd_to_lod/huwise_setup.py
@@ -40,7 +40,7 @@ def prepare_dataset_inputs(dataset_id: str, base_url: str) -> DatasetSetupResult
 
     metadata_url = f"{base_url}/catalog/datasets/{quote(dataset_id)}"
     csv_url = f"{base_url}/catalog/datasets/{quote(dataset_id)}/exports/csv?" + urlencode(
-        {"delimiter": ",", "use_labels": "true"}
+        {"delimiter": ",", "use_labels": "true", "limit": "20"}
     )
     ttl_where = f'dataset_id="{dataset_id}"'
     ttl_url = f"{base_url}/catalog/exports/ttl?" + urlencode({"where": ttl_where})

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -131,17 +131,14 @@ class TestGitHubService:
             sha="abc123",
         )
 
-        # Verify three files were committed (YARRRML + CSV + README)
-        assert mock_repo.create_file.call_count == 3
+        # Verify two files were committed (YARRRML + README)
+        assert mock_repo.create_file.call_count == 2
         calls = mock_repo.create_file.call_args_list
         rml_kwargs = calls[0][1]
-        csv_kwargs = calls[1][1]
-        readme_kwargs = calls[2][1]
+        readme_kwargs = calls[1][1]
         assert rml_kwargs["path"] == "mapping/test-mapping/mapping.yarrrml.yaml"
         assert rml_kwargs["content"] == "@prefix rr: <...> ."
         assert rml_kwargs["branch"] == "mapping/test-mapping"
-        assert csv_kwargs["path"] == "mapping/test-mapping/data.csv"
-        assert csv_kwargs["content"] == "col1,col2\n1,2\n"
         assert readme_kwargs["path"] == "mapping/test-mapping/README.md"
         assert readme_kwargs["content"] == "Test description"
 
@@ -280,8 +277,8 @@ class TestGitHubService:
             csv_content="col1\nval\n",
         )
 
-        # All three files exist → all should be updated, none created
-        assert mock_repo.update_file.call_count == 3
+        # Both files exist → both should be updated, none created
+        assert mock_repo.update_file.call_count == 2
         for call in mock_repo.update_file.call_args_list:
             assert call[1]["sha"] == "file-sha-123"
 
@@ -385,12 +382,12 @@ class TestGitHubService:
         )
 
         rml_call = mock_repo.create_file.call_args_list[0][1]
-        csv_call = mock_repo.create_file.call_args_list[1][1]
+        readme_call = mock_repo.create_file.call_args_list[1][1]
         assert rml_call["path"] == "mapping/my-dataset/mapping.yarrrml.yaml"
-        assert csv_call["path"] == "mapping/my-dataset/data.csv"
+        assert readme_call["path"] == "mapping/my-dataset/README.md"
 
-    def test_csv_file_committed_alongside_rml(self, github_config, mock_github):
-        """The CSV source file is committed alongside the YARRRML mapping."""
+    def test_csv_file_not_committed(self, github_config, mock_github):
+        """The CSV source file is not committed to GitHub."""
         mock_repo = MagicMock()
         mock_github.return_value.get_repo.return_value = mock_repo
 
@@ -417,12 +414,11 @@ class TestGitHubService:
             csv_content="year,value\n2024,100\n",
         )
 
-        assert mock_repo.create_file.call_count == 3
+        assert mock_repo.create_file.call_count == 2
         calls = mock_repo.create_file.call_args_list
         assert calls[0][1]["path"] == "mapping/with-csv/mapping.yarrrml.yaml"
-        assert calls[1][1]["path"] == "mapping/with-csv/population.csv"
-        assert calls[1][1]["content"] == "year,value\n2024,100\n"
-        assert calls[2][1]["path"] == "mapping/with-csv/README.md"
+        assert calls[1][1]["path"] == "mapping/with-csv/README.md"
+        assert all(call[1]["path"] != "mapping/with-csv/population.csv" for call in calls)
 
     def test_custom_mappings_folder(self, github_config, mock_github):
         """Override the mappings_folder parent."""
@@ -455,11 +451,10 @@ class TestGitHubService:
 
         calls = mock_repo.create_file.call_args_list
         assert calls[0][1]["path"] == "mappings/custom/mapping.yarrrml.yaml"
-        assert calls[1][1]["path"] == "mappings/custom/data.csv"
-        assert calls[2][1]["path"] == "mappings/custom/README.md"
+        assert calls[1][1]["path"] == "mappings/custom/README.md"
 
     def test_metadata_file_committed_when_provided(self, github_config, mock_github):
-        """metadata.ttl is committed alongside YARRRML and CSV when provided."""
+        """metadata.ttl is committed alongside YARRRML when provided."""
         mock_repo = MagicMock()
         mock_github.return_value.get_repo.return_value = mock_repo
 
@@ -487,13 +482,12 @@ class TestGitHubService:
             metadata_content="<https://ex.org/> a cube:Cube .",
         )
 
-        assert mock_repo.create_file.call_count == 4
+        assert mock_repo.create_file.call_count == 3
         calls = mock_repo.create_file.call_args_list
         assert calls[0][1]["path"] == "mapping/with-meta/mapping.yarrrml.yaml"
-        assert calls[1][1]["path"] == "mapping/with-meta/data.csv"
-        assert calls[2][1]["path"] == "mapping/with-meta/metadata.ttl"
-        assert calls[2][1]["content"] == "<https://ex.org/> a cube:Cube ."
-        assert calls[3][1]["path"] == "mapping/with-meta/README.md"
+        assert calls[1][1]["path"] == "mapping/with-meta/metadata.ttl"
+        assert calls[1][1]["content"] == "<https://ex.org/> a cube:Cube ."
+        assert calls[2][1]["path"] == "mapping/with-meta/README.md"
 
     def test_metadata_file_omitted_when_none(self, github_config, mock_github):
         """No metadata.ttl is committed when metadata_content is None."""
@@ -523,7 +517,7 @@ class TestGitHubService:
             csv_content="col1\nval\n",
         )
 
-        assert mock_repo.create_file.call_count == 3
+        assert mock_repo.create_file.call_count == 2
         paths = [c[1]["path"] for c in mock_repo.create_file.call_args_list]
         assert all("metadata.ttl" not in p for p in paths)
         assert "mapping/no-meta/README.md" in paths


### PR DESCRIPTION
## Summary

Adds the proposed CSV source URL confirmation flow for `--dataset-id` mode, plus two small improvements to dataset-id sample handling. This is a focused, rebuilt replacement for the previously closed #66 (which had bundled the now-merged `--dataset-id` workflow from #64).

## Changes

- **CSV source URL confirmation flow** (`cli.py`, `graph/flow.py`, `graph/state.py`): when running in `--dataset-id` mode, the proposed public CSV source URL is shown and the user is asked to confirm (yes/no) before it's used, with a fallback to manually entering a URL.
- **Limit the sample download to 20 rows** (`huwise_setup.py`): the `data.csv` fetched for mapping generation now requests `limit=20`, which keeps dataset-id setup fast. `use_labels` is intentionally left at `true` to stay consistent with the example data, the generated mappings (which reference label columns, e.g. `$(O3 [ug/m3])`), and the `dcat:downloadURL`s.
- **Stop committing `data.csv`** (`github/service.py`, `tests/test_github.py`): generated `data.csv` is no longer included in mapping PRs.

## Notes

- The sample download is now capped at 20 rows for every `--dataset-id` run.
